### PR TITLE
Use latest server.js version on instructions to compile

### DIFF
--- a/DEBIAN.md
+++ b/DEBIAN.md
@@ -56,7 +56,7 @@ This will create the `stremio' binary.
 
 Upon running the ./stremio binary, stremio should start up as usual. Except it won't start the streaming server, for this you need to have NodeJS installed and server.js, stremio.asar in your working dir, for which you need to do:
 
-``wget https://dl.strem.io/four/v4.4.10/server.js ; wget https://dl.strem.io/four/v4.4.10/stremio.asar``
+``wget https://dl.strem.io/four/v4.4.111/server.js ; wget https://dl.strem.io/four/v4.4.111/stremio.asar``
 
 
 ## 6. Install other dependencies


### PR DESCRIPTION
Update to version 4.4.111 (the latest server.js version) in the instructions to compile stremio-shell in Debian.