### PR TITLE
Sleep before checking if stremio.exe is running

### DIFF
--- a/windows/installer/windows-installer.nsi
+++ b/windows/installer/windows-installer.nsi
@@ -168,7 +168,8 @@ done:
 FunctionEnd
 
 Section ; App Files
-    ; Sleep 2 seconds to ensure stremio has quit (if we are autoupdating)
+    ; Sleep 3 seconds to ensure stremio has quit (if we are autoupdating)
+    ; the quitApp() call in main.qml waits 2.5 seconds for the server
     Sleep 2000
 
     check:

--- a/windows/installer/windows-installer.nsi
+++ b/windows/installer/windows-installer.nsi
@@ -168,6 +168,9 @@ done:
 FunctionEnd
 
 Section ; App Files
+    ; Sleep 2 seconds to ensure stremio has quit (if we are autoupdating)
+    Sleep 2000
+
     check:
     ; Check if stremio.exe is running
     ${nsProcess::FindProcess} "stremio.exe" $R0


### PR DESCRIPTION
Helps when the autoupdater is running the installer, because sometimes it will run it before the app has truly quit, leading to an error message that stremio is still running