### PR TITLE
The submodules are public repos, appveyor key is not needed

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,11 +12,6 @@ environment:
 
 install:
   - git submodule update --init --recursive
-  # Set the OS private key, so we can authenticate for the repos
-  - ps: $fileContent = "-----BEGIN RSA PRIVATE KEY-----`n"
-  - ps: $fileContent += $env:priv_key.Replace(' ', "`n")
-  - ps: $fileContent += "`n-----END RSA PRIVATE KEY-----`n"
-  - ps: Set-Content c:\users\appveyor\.ssh\id_rsa $fileContent
 
   # Install OpenSSL
   - ps: Start-FileDownload 'https://slproweb.com/download/Win32OpenSSL-1_1_1h.exe'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,11 @@ environment:
   aws_key: AKIAJWBFLU34IVITPLHA
   aws_secret:
     secure: X/MRT0y7Yb8tnzdcQ8Lq+A+/Yc5Ad2KWFYpaydFz0zDSaq8PxZ8XbFseDxjKYo6c
+  DEPLOY: true
+
+init:
+  # Prevent pull requests from attempting to sign package.
+  - if NOT "%APPVEYOR_PULL_REQUEST_NUMBER%" == "" set DEPLOY=false
 
 install:
   - git submodule update --init --recursive
@@ -121,12 +126,12 @@ test_script:
   - windeployqt --release --no-compiler-runtime --qmldir=. ./dist-win/stremio.exe
 
   # sign-windows-files
-  - SignTool sign /f ./windows/smartcode-20181204-20211204.pfx /p %CERT_PASS%  ./dist-win/stremio.exe
-  - SignTool sign /f ./windows/smartcode-20181204-20211204.pfx /p %CERT_PASS%  ./dist-win/ffmpeg.exe
+  - if "%DEPLOY%" == "true" SignTool sign /f ./windows/smartcode-20181204-20211204.pfx /p %CERT_PASS%  ./dist-win/stremio.exe
+  - if "%DEPLOY%" == "true" SignTool sign /f ./windows/smartcode-20181204-20211204.pfx /p %CERT_PASS%  ./dist-win/ffmpeg.exe
 
   # build-windows-installer
   - makensis -V2 ./windows/installer/windows-installer.nsi
-  - SignTool sign /f ./windows/smartcode-20181204-20211204.pfx /p %CERT_PASS% *.exe
+  - if "%DEPLOY%" == "true" SignTool sign /f ./windows/smartcode-20181204-20211204.pfx /p %CERT_PASS% *.exe
 
   # TODO: test if stremio.exe starts properly; because the missing DLLs errors are handled at run-time, we cannot catch them sanely
   # we can mix that with the server integration test, then we'd be able to detect some sanity
@@ -146,6 +151,8 @@ deploy:
   set_public: true
   folder: shell-win/$(UPLOAD_PATH)
   max_error_retry: 1
+  on:
+    DEPLOY: true
 
 # We need to customize the Slack notification so we add messages and links to artifacts
 notifications:


### PR DESCRIPTION
All git submodules are public repos, appveyor key for checking out the submodules' repositories is not needed
This also unbreaks CI builds for pull requests