### PR TITLE
Fix debian package

### DIFF
--- a/.github/workflows/shell.yaml
+++ b/.github/workflows/shell.yaml
@@ -48,6 +48,10 @@ jobs:
 
       - name: Dependencies
         run: |
+          brew uninstall openssl@1.0.2t
+          brew uninstall python@2.7.17
+          brew untap local/openssl
+          brew untap local/python2
           brew update-reset
           brew update
           npm -g install appdmg

--- a/distros/Ubuntu/Dockerfile
+++ b/distros/Ubuntu/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04
 
 # Install package dependencies
-RUN apt update && apt install -y git librsvg2-bin checkinstall nodejs build-essential qt5-default qtdeclarative5-dev qtdeclarative5-dev-tools qtwebengine5-dev qml-module-qtquick-controls qml-module-qtquick-dialogs qml-module-qt-labs-platform qml-module-qtwebchannel qml-module-qtwebengine wget libssl-dev sudo zlib1g-dev libuchardet-dev librubberband-dev libfreetype6-dev libfribidi-dev libfontconfig1-dev python devscripts equivs yasm libx264-dev libmp3lame-dev libfdk-aac-dev  libpulse-dev libasound2-dev
+RUN apt update && apt install -y git librsvg2-bin checkinstall nodejs build-essential qt5-default qtdeclarative5-dev qtdeclarative5-dev-tools qtwebengine5-dev qml-module-qtquick-controls qml-module-qtquick-dialogs qml-module-qt-labs-platform qml-module-qtwebchannel qml-module-qtwebengine wget libssl-dev sudo zlib1g-dev libuchardet-dev librubberband-dev libfreetype6-dev libfribidi-dev libfontconfig1-dev python devscripts equivs yasm libx264-dev libmp3lame-dev libfdk-aac-dev  libpulse-dev libasound2-dev libharfbuzz-dev
 
 # Setting up new user
 RUN useradd builduser -m


### PR DESCRIPTION
There is new MPV dependency - harfbuzz. By installing libharfbuzz-dev the MPV build is successful again.

This is tested and works fine on Ubuntu 18.04. For Ubuntu 20.04 we don't need to build MPV from source. The system version is 0.32 - the one we need. The current package will not run on Ubuntu 20.04 unless libmpv.so.1 in /opt/stremio/ is replaced with the system one due to other dependencies.