### PR TITLE
Better check for network availability

### DIFF
--- a/autoupdater.cpp
+++ b/autoupdater.cpp
@@ -1,8 +1,33 @@
 #include <autoupdater.h>
-#include <QDebug>
+#include <QTimer>
 
-AutoUpdater::AutoUpdater() {
+AutoUpdater::AutoUpdater(): manager(new QNetworkAccessManager(this)), nsManager(new QNetworkAccessManager(this)) {
     init_public_key();
+    nsManager->setTransferTimeout(NS_TEST_CONN_TIMEOUT);
+    QObject::connect(this, &AutoUpdater::performPing, this, [=]() {
+        nsManager->get(QNetworkRequest(QUrl(NS_TEST_ENDPOINT)));
+    });
+    QObject::connect(nsManager, &QNetworkAccessManager::finished,
+        this, [=](QNetworkReply *resp) {
+            if (!resp->error()) {
+                
+                QVariant status_code = resp->attribute(QNetworkRequest::HttpStatusCodeAttribute);
+                if(status_code.isValid()) {
+                    auto status = status_code.toInt();
+                    if(status == NS_TEST_STATUS) {
+                        emit networkStatus(true);
+                        return;
+                    }
+                }
+            }
+            if(nsRetries >= NS_TEST_RETRIES) {
+                emit networkStatus(false);
+                return;
+            }
+            nsRetries++;
+            QTimer::singleShot(NS_TEST_RETRY_TIMEOUT, this, [=](){ emit performPing(); });
+        }
+    );
 }
 
 // HANDLE FATAL ERRORS
@@ -89,16 +114,14 @@ int AutoUpdater::executeCmd(QString cmd, QStringList args, bool noWait = false) 
     return proc.exitCode();
 }
 
-bool AutoUpdater::isOnline() {
-    QNetworkConfigurationManager mgr;
-    return mgr.isOnline();
+void AutoUpdater::checkNetworkStatus() {
+    nsRetries = 0;
+    emit performPing();
 }
 
 // CHECK FOR UPDATES
 void AutoUpdater::checkForUpdatesPerform(QString endpoint, QString userAgent)
 {
-    if (! manager) manager = new QNetworkAccessManager(this);
-
     QByteArray serverHash = getFileChecksum(QCoreApplication::applicationDirPath() +  QDir::separator() + SERVER_FNAME);
     QByteArray asarHash = getFileChecksum(QCoreApplication::applicationDirPath() +  QDir::separator() + ASAR_FNAME);
 

--- a/autoupdater.cpp
+++ b/autoupdater.cpp
@@ -3,7 +3,7 @@
 
 AutoUpdater::AutoUpdater(): manager(new QNetworkAccessManager(this)), nsManager(new QNetworkAccessManager(this)) {
     init_public_key();
-    nsManager->setTransferTimeout(NS_TEST_CONN_TIMEOUT);
+    // nsManager->setTransferTimeout(NS_TEST_CONN_TIMEOUT); // This is Qt 5.15 only
     QObject::connect(this, &AutoUpdater::performPing, this, [=]() {
         nsManager->get(QNetworkRequest(QUrl(NS_TEST_ENDPOINT)));
     });

--- a/autoupdater.h
+++ b/autoupdater.h
@@ -39,6 +39,20 @@ extern "C" {
     #define FULL_UPDATE_FILES { }
 #endif
 
+// Network status test configuration
+
+// The checked URL 
+// This URL is borrowed from here https://www.chromium.org/chromium-os/chromiumos-design-docs/network-portal-detection
+#define NS_TEST_ENDPOINT "http://clients3.google.com/generate_204"
+// Expected status code
+#define NS_TEST_STATUS 204
+// Connection timeout (ms)
+#define NS_TEST_CONN_TIMEOUT 10000
+// Retry wait time (ms)
+#define NS_TEST_RETRY_TIMEOUT 3000
+// Number of retries to be performed
+#define NS_TEST_RETRIES 3
+
 typedef QPair<QUrl, QByteArray> fDownload;
 
 class AutoUpdater : public QObject
@@ -59,9 +73,11 @@ class AutoUpdater : public QObject
 
     bool moveFileToAppDir(QString);
     int executeCmd(QString, QStringList, bool);
-    bool isOnline();
+    void checkNetworkStatus();
 
     signals:
+    void performPing();
+    void networkStatus(bool);
     void error(QString, QVariant);
     void checkFinished(QVariant);
     void prepared(QVariantList, QVariant);
@@ -89,6 +105,8 @@ class AutoUpdater : public QObject
     QByteArray getFileChecksum(QString);
 
     QNetworkAccessManager* manager = NULL;
+    QNetworkAccessManager* nsManager = NULL;
+    uint8_t nsRetries;
 
     // State; must be reset on abort
     QJsonDocument currentVersionDesc;

--- a/autoupdater.h
+++ b/autoupdater.h
@@ -46,8 +46,8 @@ extern "C" {
 #define NS_TEST_ENDPOINT "http://clients3.google.com/generate_204"
 // Expected status code
 #define NS_TEST_STATUS 204
-// Connection timeout (ms)
-#define NS_TEST_CONN_TIMEOUT 10000
+// Connection timeout (ms) - This is Qt 5.15 only
+// #define NS_TEST_CONN_TIMEOUT 10000
 // Retry wait time (ms)
 #define NS_TEST_RETRY_TIMEOUT 3000
 // Number of retries to be performed

--- a/autoupdater.js
+++ b/autoupdater.js
@@ -27,13 +27,8 @@
             console.log("Auto-updater: skipping, possibly not running an installed app?")
             return
         }
-        
-        // This is the timeout we use to check periodically; the signal is handled in the main (UI) thread
-        var onTriggered
-        shortTimer.triggered.connect(onTriggered = function() {
-            // WARNING: what if .isOnline() fails on some system?? it's based on QNetworkConfigurationManager
-            // can we trust it??
-            if (autoUpdater.isOnline()) {
+        autoUpdater.networkStatus.connect(function(isOnline) {
+            if (isOnline) {
                 console.log("Auto-updater: checking for new version")
                 autoUpdater.abort()
                 autoUpdater.checkForUpdates(autoUpdater.endpoint(), userAgent)
@@ -42,6 +37,11 @@
                 console.log("Auto-update: skip check because we're not online")
                 shortTimer.restart()
             }
+        });
+        // This is the timeout we use to check periodically; the signal is handled in the main (UI) thread
+        var onTriggered
+        shortTimer.triggered.connect(onTriggered = function() {
+            autoUpdater.checkNetworkStatus();
         })
         onTriggered(); // initial check
 


### PR DESCRIPTION
Fixes https://github.com/Stremio/stremio-shell/issues/160

This check just pings Google's generate_204 page. If the response is not 204 or there is an error the check is performed again up to configurable amount of times then networkStatus signal is raised with negative status. Otherwise the networkStatus signal gets positive status and we assume that we are online.

This solution should work on any platform.