### PR TITLE
Silent installer + command line config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ build-*/
 stremio.app/*
 /build/*
 moc_*.h
-
+/dist-win/
 # QtCreator
 
 *.autosave

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -10,7 +10,7 @@ Requirements
 * Microsoft Visual Studio
 * QT
 * OpenSSL
-* NodeJs
+* Node.js
 * FFmpeg
 * MPV
 
@@ -24,17 +24,15 @@ Download and install Microsoft Visual Studio Community 2017 from here https://vi
 
 Download and install QT 5.12.7 from here http://download.qt.io/official_releases/qt/5.12/5.12.7/qt-opensource-windows-x86-5.12.7.exe (I had to disconnect from the Internet in order to skip the account log in/registration). In the setup select QT version for **MSVC 2017 32 bit**. Also the **Qt WebEngine** component must be selected for installation.
 
-Download and install **Win32 OpenSSL v1.1.0** from https://slproweb.com/products/Win32OpenSSL.html
+Download and install **Win32 OpenSSL v1.1.1** from https://slproweb.com/products/Win32OpenSSL.html
 The full version is required. The light version doesn't include all necessary files.
 
-Download NodeJs from here https://nodejs.org/dist/v8.17.0/win-x86/node.exe
+Download Node.js from here https://nodejs.org/dist/v8.17.0/win-x86/node.exe
 
 Download FFmpeg from https://ffmpeg.zeranoe.com/builds/win32/static/ffmpeg-3.3.4-win32-static.zip
 Other version may also work.
 
-Download MPV from here https://sourceforge.net/projects/mpv-player-windows/files/libmpv/ We need `mpv-dev-i686` version. Stremio is tested to work with mpv-dev-i686-20200610-git-c7fe4ae.7z
-
-Download stremio-server from here https://s3-eu-west-1.amazonaws.com/stremio-artifacts/four/v4.4.116/server.js where v4.4.116 is the shell version.
+The MPV library is obtained from here https://sourceforge.net/projects/mpv-player-windows/files/libmpv/ We use `mpv-dev-i686` version. For convenience it is already in the windows directory of the project
 
 Open command prompt and run the following commands:
 
@@ -50,28 +48,64 @@ Add QT and OpenSSL to the system Path
 Setup the environment
 
 		"C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x86
+		FOR /F "usebackq delims== tokens=2" %i IN (`type stremio.pro ^| find "VERSION=4"`) DO set package_version=%i
+
+Download server.js
+
+		powershell -Command Start-BitsTransfer -Source "https://s3-eu-west-1.amazonaws.com/stremio-artifacts/four/v%package_version%/server.js" -Destination server.js
+
 
 Build the shell
 
 		qmake .
 		nmake
 
-Now create new folder where we will put the final product:
+Now create new folder where we will put the final product and copy there the required files:
 
-		mkdir stremio-windows
-		copy release\stremio.exe stremio-windows\
-		copy C:\Windows\System32\msvcr120.dll stremio-windows\
-		copy C:\OpenSSL-Win32\bin\libcrypto-1_1.dll stremio-windows\
+		mkdir dist-win
+		copy release\stremio.exe dist-win\
+		copy windows\msvcr120.dll dist-win\
+		copy windows\mpv-1.dll dist-win\
+		copy windows\DS\* dist-win\
+		copy server.js dist-win\
+		copy C:\OpenSSL-Win32\bin\libcrypto-1_1.dll dist-win\
 
-You need to also put the following previously downloaded files in the stremio-windows folder:
+You need to also put the following previously downloaded files in the dist-win folder:
 
  * node.exe
  * ffmpeg.exe from the ffmpeg-3.3.4-win32-static.zip
- * mpv-1.dll from the mpv-dev-i686 archive
- * server.js
 
  The last step is do deploy the QT dependencies:
 
-		windeployqt --qmldir . stremio-windows\stremio.exe
+		windeployqt --qmldir . dist-win\stremio.exe
 
-Now inside the stremio-windows folder should be located all necessary files for the shell to work.
+Now inside the dist-win folder should be located all necessary files for the shell to work.
+
+Installer (optional)
+---
+
+Download NSIS from here https://nsis.sourceforge.io/Download and install it. The default installation path is `C:\Program Files (x86)\NSIS`
+
+WARNING: Before packing the application make sure it behaves as expected.
+
+If you build the installer in another command prompt or at latter time you need to set again the `package_version` environment variable as it is required by the installer script. To generate it you can run the following commands from the root directory of the stremio-shell repository:
+
+		FOR /F "usebackq delims== tokens=2" %i IN (`type stremio.pro ^| find "VERSION=4"`) DO set package_version=%i
+		"C:\Program Files (x86)\NSIS\makensis.exe" windows\installer\windows-installer.nsi
+
+This will generate `Stremio %package_version%.exe` - the Stremio installer where `%package_version%` is the current Stremio version.
+
+The Stremio installer silent mode
+--
+
+By default the installer has GUI but you can run it in silent mode with the `/S` argument (case sensitive). When in silent mode it supports some additional configuration via command line arguments as follows:
+
+		/notorrentassoc - does not associate Stremio with .torrent files
+		/nodesktopicon - does not create Desktop shortcut for Stremio
+
+The default behavior is the opposite of what the arguments do.
+
+
+Once installed Stremio is located in `%LOCALAPPDATA%\Programs\LNV\Stremio-4\` directory. The uninstaller also have a silent mode when `/S` argument is present. By default everything is removed. If silent uninstall is required but the user's data have to be kept the uninstaller can be called like this:
+
+	"%LOCALAPPDATA%\Programs\LNV\Stremio-4\Uninstall.exe" /S /keepdata

--- a/windows/installer/windows-installer.nsi
+++ b/windows/installer/windows-installer.nsi
@@ -1,6 +1,8 @@
 ;Stremio
 ;Installer Source for NSIS 3.0 or higher
 
+Unicode True
+
 #Tells the compiler whether or not to do datablock optimizations.
 SetDatablockOptimize on
 
@@ -128,6 +130,8 @@ LangString noRoot ${LANG_ENGLISH} "You cannot install Stremio in a directory tha
 LangString desktopShortcut ${LANG_ENGLISH} "Desktop Shortcut"
 LangString appIsRunning ${LANG_ENGLISH} "${APP_NAME} is running. Please close it and press OK to continue."
 
+Var Parameters
+
 # Finish page custom options
 Var AssociateTorrentCheckbox
 Var checkbox_value
@@ -136,15 +140,18 @@ Function fin_pg_options
   Pop $AssociateTorrentCheckbox
   SetCtlColors $AssociateTorrentCheckbox '0xFF0000' '0xFFFFFF'
   ${NSD_Check} $AssociateTorrentCheckbox
-  ;GetFunctionAddress $0 fin_pg_leave
-	;nsDialogs::OnClick $AssociateTorrentCheckbox $0
 Functionend
 
 Function fin_pg_leave
   ${NSD_GetState} $AssociateTorrentCheckbox $checkbox_value
-
+  IfSilent 0 assoc
+  StrCpy $checkbox_value ${BST_UNCHECKED}
+  ${GetOptions} $Parameters /notorrentassoc $R1
+  IfErrors 0 assoc
+  StrCpy $checkbox_value ${BST_CHECKED}
+  assoc:
+  ;MessageBox MB_OK $checkbox_value
   ${If} $checkbox_value == ${BST_CHECKED}
-		;MessageBox MB_OK "checkbox clicked"
     !insertmacro APP_ASSOCIATE "torrent" "stremio" "BitTorrent file" "$INSTDIR\stremio.exe,0" "Play with Stremio" "$INSTDIR\stremio.exe $\"%1$\""
 	${EndIf}
 Functionend
@@ -157,9 +164,9 @@ Function .onInit ; check for previous version
     StrCmp $0 "" done
     StrCpy $INSTDIR $0
 
-    ${GetParameters} $R0
-
-    ${GetOptions} $R0 "/addon" $R1
+    ${GetParameters} $Parameters
+    ClearErrors
+    ${GetOptions} $Parameters "/addon" $R1
 
     FileOpen $0 "$INSTDIR\addons.txt" w
     FileWrite $0 "$R1"
@@ -170,12 +177,16 @@ FunctionEnd
 Section ; App Files
     check:
     ; Check if stremio.exe is running
-    ${nsProcess::FindProcess} "stremio.exe" $R0
+    ${nsProcess::FindProcess} ${APP_LAUNCHER} $R0
 
     ${If} $R0 == 0
+        IfSilent killapp
         MessageBox MB_OK "$(appIsRunning)"
         Goto check
-    ${EndIf}    
+        killapp:
+        ${nsProcess::CloseProcess} "${APP_LAUNCHER}" $R0
+        Sleep 2000
+    ${EndIf}
 
     ${nsProcess::Unload}
 
@@ -235,22 +246,28 @@ Section ; Shortcuts
     ; Register stremio:// protocol handler
     WriteRegStr HKCU "Software\Classes\stremio" "" "URL:Stremio Protocol"
     WriteRegStr HKCU "Software\Classes\stremio" "URL Protocol" ""
-    WriteRegStr HKCU "Software\Classes\stremio\DefaultIcon" "" $INSTDIR\stremio.exe,1
+    WriteRegStr HKCU "Software\Classes\stremio\DefaultIcon" "" "$INSTDIR\stremio.exe,1"
     WriteRegStr HKCU "Software\Classes\stremio\shell" "" "open"
     WriteRegStr HKCU "Software\Classes\stremio\shell\open\command" "" '"$INSTDIR\stremio.exe" "%1"'
 
     ; Register magnet:// protocol handler
     WriteRegStr HKCU "Software\Classes\magnet" "" "URL:BitTorrent magnet"
     WriteRegStr HKCU "Software\Classes\magnet" "URL Protocol" ""
-    WriteRegStr HKCU "Software\Classes\magnet\DefaultIcon" "" $INSTDIR\stremio.exe,1
+    WriteRegStr HKCU "Software\Classes\magnet\DefaultIcon" "" "$INSTDIR\stremio.exe,1"
     WriteRegStr HKCU "Software\Classes\magnet\shell" "" "open"
     WriteRegStr HKCU "Software\Classes\magnet\shell\open\command" "" '"$INSTDIR\stremio.exe" "%1"'
+    IfSilent 0 end
+    Call fin_pg_leave
+    ${GetOptions} $Parameters /nodesktopicon $R1
+    IfErrors 0 end
+    Call finishpageaction
+    end:
 SectionEnd
 
 ; ------------------- ;
 ;     Uninstaller     ;
 ; ------------------- ;
-Section "uninstall" 
+Section "uninstall"
     SetDetailsPrint none
 
     check:
@@ -258,9 +275,13 @@ Section "uninstall"
     ${nsProcess::FindProcess} "stremio.exe" $R0
 
     ${If} $R0 == 0
+        IfSilent killapp
         MessageBox MB_OK "$(appIsRunning)"
         Goto check
-    ${EndIf}    
+        killapp:
+        ${nsProcess::CloseProcess} "${APP_LAUNCHER}" $R0
+        Sleep 2000
+    ${EndIf}
 
     ${nsProcess::Unload}
 
@@ -274,11 +295,19 @@ Section "uninstall"
 
     !insertmacro APP_UNASSOCIATE "torrent" "stremio"
 
+    IfSilent +3
     MessageBox MB_YESNO|MB_ICONQUESTION "$(removeDataFolder)" IDNO KeepUserData
+    goto notsilent
+    ${GetParameters} $Parameters
+    ClearErrors
+    ${GetOptions} $Parameters "/keepdata" $R1
+    IfErrors 0 KeepUserData
+    notsilent:
       RMDir /r "$LOCALAPPDATA\${COMPANY_NAME}"
       RMDir /r "$APPDATA\${DATA_FOLDER}"
     KeepUserData:
 
+    IfSilent +2
     ExecShell "open" "http://www.strem.io/goodbye"
 SectionEnd
 
@@ -353,7 +382,7 @@ Function .onVerifyInstDir
   IntCmp $R1 0 pathgood
   Pop $R1
   Call CloseBrowseForFolderDialog
-  MessageBox MB_OK|MB_USERICON "$(noRoot)"
+  MessageBox MB_OK|MB_USERICON "$(noRoot)" /SD IDOK
   Abort
 
 pathgood:


### PR DESCRIPTION
Fixes https://github.com/Stremio/stremio-shell/issues/181

Stremio is killed instead of prompting to close it if running when the installer/uninstaller is run in silent mode
The uninstaller does not open the goodbye page in silent mode

New command line options for the installer in silent mode:
/notorrentassoc - does not associate Stremio with .torrent files
/nodesktopicon - does not create Desktop shortcut for Stremio

New command line option for the uninstaller in silent mode:
/keepdata - does not remove the user data
