### PR TITLE
Fix for rebranded node icon and signature

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -98,7 +98,7 @@ test_script:
   # copy-windows-ffmpeg
   - move "%FFMPEG_BIN_PATH%\ffmpeg.exe" dist-win
   # copy-windows-node (stremio-runtime)
-  - ps: & $(Join-Path $env:DLL_DIR "generate_stremio-runtime.cmd") dist-win
+  - ps: '& $(Join-Path $env:DLL_DIR "generate_stremio-runtime.cmd") dist-win'
   # copy-windows-server
   - appveyor DownloadFile https://s3-eu-west-1.amazonaws.com/stremio-artifacts/four/v%package_version%/server.js -FileName dist-win\server.js
   # Patch server.js in order to work with node 14

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -98,7 +98,7 @@ test_script:
   # copy-windows-ffmpeg
   - move "%FFMPEG_BIN_PATH%\ffmpeg.exe" dist-win
   # copy-windows-node (stremio-runtime)
-  - ps: cmd /c $(Join-Path $env:DLL_DIR "generate_stremio-runtime.cmd") dist-win
+  - ps: & $(Join-Path $env:DLL_DIR "generate_stremio-runtime.cmd") dist-win
   # copy-windows-server
   - appveyor DownloadFile https://s3-eu-west-1.amazonaws.com/stremio-artifacts/four/v%package_version%/server.js -FileName dist-win\server.js
   # Patch server.js in order to work with node 14

--- a/windows/generate_stremio-runtime.cmd
+++ b/windows/generate_stremio-runtime.cmd
@@ -24,6 +24,11 @@ if not exist "%rt_path%\" goto :nodir
 set "res_dir=%TEMP%\srres"
 md "%res_dir%"
 
+:: Copy node.exe to the temp dir and remove signature
+copy %node% "%res_dir%\node.exe"
+set node="%res_dir%\node.exe"
+signtool remove /s %node%
+
 :: Extract Node.js resources
 %rh% -open %node% -save "%res_dir%\resources.rc" -action extract -mask ",,"
 

--- a/windows/generate_stremio-runtime.cmd
+++ b/windows/generate_stremio-runtime.cmd
@@ -45,7 +45,7 @@ pushd "%res_dir%"
 popd
 
 :: Build the stremio-runtime executable
-%rh% -open %node% -saveas %rt_exe% -action modify -res "%res_dir%\stremio-rt.res"
+%rh% -open %node% -saveas %rt_exe% -action addoverwrite -res "%res_dir%\stremio-rt.res"
 
 :: Cleanup
 rd /S /Q "%res_dir%"


### PR DESCRIPTION
Turns out I need to remove the signature before I decompile node.exe. Then after the changes I can successfully sign it with our certificate.