### PR TITLE
Fix Mac OS build failure due to changes in iina

### DIFF
--- a/.github/workflows/shell.yaml
+++ b/.github/workflows/shell.yaml
@@ -82,8 +82,7 @@ jobs:
           
       - name: Fix dependencies
         run: |
-          cp ./iina/deps/lib/* ./stremio.app/Contents/Frameworks
-          #./mac/fix_osx_deps.sh "./stremio.app/Contents/Frameworks" "@executable_path/../Frameworks"
+          cp ./deps/lib/* ./stremio.app/Contents/Frameworks
 
       - name: Testdrive
         run: ( $DEST_DIR/stremio & sleep 10 && STREMIO_PID=$! && kill $STREMIO_PID )

--- a/.github/workflows/shell.yaml
+++ b/.github/workflows/shell.yaml
@@ -56,7 +56,8 @@ jobs:
       - name: Build
         run: |
           git clone https://github.com/iina/iina
-          export MPV_BIN_PATH=$(pwd)/iina/deps
+          bash ./iina/other/download_libs.sh
+          export MPV_BIN_PATH=$(pwd)/deps
           ( cd $MPV_BIN_PATH/lib && ln -s libmpv.1.dylib libmpv.dylib )
           export OPENSSL_BIN_PATH=$(brew --prefix openssl)
           qmake .


### PR DESCRIPTION
Iina no longer provide the binary libs within the repo. They have a download script and host the libraries separately. There are three ways we can deal with that.

1. copy their download script
  Pros: very easy to do
  Cons: if they change the download script we also need to do so. It is not very fast
2. clone the repo and run the download script
  Pros: very easy to do and no need to maintain the download script
  Cons: if they change the name of the download script we also need to do so. It is the slowest option as the repo is downloaded alongside the binaries
3. add the binaries to our repo
  Pros: we'll have the fastest build process. No need to download files from Internet
  Cons: could be some reason (maybe legal or github storage) not to include the binaries in the repo. We need to manually update the libs when there is a new version

All methods has their advantages and disadvantages. Here I picked the second. I accept better suggestions