### PR TITLE
Generic file/directory input dialog via IPC

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -562,13 +562,17 @@ ApplicationWindow {
       folder: shortcuts.home
       onAccepted: {
         var fileProtocol = "file://"
+        var onWindows = Qt.platform.os === "windows" ? 1 : 0
+        var pathSeparators = ["/", "\\"]
         var files = fileDialog.fileUrls.filter(function(fileUrl) {
           // Ignore network drives and alike
           return fileUrl.startsWith(fileProtocol)
         })
         .map(function(fileUrl) {
           // Send actual path and not file protocol URL
-          return decodeURIComponent(fileUrl.substring(fileProtocol.length + (Qt.platform.os === "windows" ? 1 : 0)))
+          return decodeURIComponent(fileUrl
+            .substring(fileProtocol.length + onWindows))
+            .replace(/\//g, pathSeparators[onWindows])
         })
         transport.event("file-selected", {
           files: files,

--- a/main.qml
+++ b/main.qml
@@ -9,7 +9,6 @@ import com.stremio.screensaver 1.0
 import com.stremio.libmpv 1.0
 import com.stremio.clipboard 1.0
 import QtQml 2.2
-// import Qt.labs.platform 1.0
 
 import "autoupdater.js" as Autoupdater
 
@@ -562,13 +561,14 @@ ApplicationWindow {
       id: fileDialog
       folder: shortcuts.home
       onAccepted: {
+        var fileProtocol = "file://"
         var files = fileDialog.fileUrls.filter(function(fileUrl) {
           // Ignore network drives and alike
-          return fileUrl.startsWith("file:///")
+          return fileUrl.startsWith(fileProtocol)
         })
         .map(function(fileUrl) {
           // Send actual path and not file protocol URL
-          return decodeURIComponent(fileUrl.substring(Qt.platform.os === "windows" ? 8 : 7))
+          return decodeURIComponent(fileUrl.substring(fileProtocol.length + (Qt.platform.os === "windows" ? 1 : 0)))
         })
         transport.event("file-selected", {
           files: files,


### PR DESCRIPTION
Unlike `<input type="file" />` this dialog sends the actual path to the Web UI. This is useful for things like:

  * Loading subtitles (besides drag & drop)
  * Changing the cache path
  * Providing MPV config path

to name a few.

# How to test

  1. Place somewhere in the app (I did it in settings) a button like this:

settings.jade:
```
.button.button-s(ng-click="ipc.send('file-open', {title: 'Test file open dialog', selectMultiple: true, selectFolder: false, data:'some test data'})"  tabindex="-1") Test
```

  2. Add an event handler for the IPC:

settings.js:
```
ipc.on("file-selected", function(a){alert(JSON.stringify(a, null, 2))});
```

  3. Run this build of the shell in development mode. Press the button and you should be prompted with file selector. Choose some files and you will see a message box displaying something like:

```
{
  "data": "some test data",
  "files": [
    "/opt/stremio/smartcode-stremio.desktop",
    "/opt/stremio/stremio/stremio"
  ],
  "nameFilters": [],
  "selectExisting": true,
  "selectFolder": false,
  "selectMultiple": true,
  "selectedNameFilter": "",
  "title": "Test file open dialog"
}
```
