### PR TITLE
Fixed Archlinux docker build 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ script:
   - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then export DEPLOY=true; else export DEPLOY=false; fi
   - echo "Deploy for build is $DEPLOY..."
   - if [ "$DEPLOY" = "true" ] && [ "$TRAVIS_OS_NAME" = "osx" ]; then s3cmd --acl-public --access_key=$AWS_ACCESS_KEY_ID --secret_key=$AWS_SECRET_ACCESS_KEY --force --region=$AWS_DEFAULT_REGION --add-header=Cache-Control:max-age=7200 put ./dist-osx/*.dmg s3://stremio-artifacts/shell-osx-old/$TAG/; fi
-  - if [ "$DEPLOY" = "true" ] && [ "$TRAVIS_OS_NAME" = "linux" ]; then shopt -s nullglob; for package in $DESTDIR/*.{deb,pkg.tar.xz,rpm}; do echo Uploading package to http://stremio-artifacts.s3.amazonaws.com/shell-linux/$TAG/$package; s3cmd --acl-public --access_key=$AWS_ACCESS_KEY_ID --secret_key=$AWS_SECRET_ACCESS_KEY --force --region=$AWS_DEFAULT_REGION --add-header=Cache-Control:max-age=7200 put "$package" s3://stremio-artifacts/shell-linux/$TAG/; done; fi
+  - if [ "$DEPLOY" = "true" ] && [ "$TRAVIS_OS_NAME" = "linux" ]; then shopt -s nullglob; for package in $DESTDIR/*.{deb,pkg.tar.zst,rpm}; do echo Uploading package to http://stremio-artifacts.s3.amazonaws.com/shell-linux/$TAG/$package; s3cmd --acl-public --access_key=$AWS_ACCESS_KEY_ID --secret_key=$AWS_SECRET_ACCESS_KEY --force --region=$AWS_DEFAULT_REGION --add-header=Cache-Control:max-age=7200 put "$package" s3://stremio-artifacts/shell-linux/$TAG/; done; fi
 
 notifications:
   slack:

--- a/distros/ArchLinux/PKGBUILD
+++ b/distros/ArchLinux/PKGBUILD
@@ -26,7 +26,7 @@ md5sums=("SKIP")
 # a description of each element in the source array.
 
 pkgver() {
-	"./$srcdir/${_pkgname}/dist-utils/common/get-version.sh"
+	"$srcdir/${_pkgname}/dist-utils/common/get-version.sh"
 }
 
 prepare() {

--- a/distros/ArchLinux/mkconfig.sh
+++ b/distros/ArchLinux/mkconfig.sh
@@ -7,5 +7,5 @@ sed -i '/^post_install/r../../dist-utils/common/postinstall' "$DEST_FILE"
 sed -i '/^pre_remove/r../../dist-utils/common/preremove' "$DEST_FILE"
 sed -i '2,${/^#!/d}' "$DEST_FILE"
 
-export COPY_CMD='cp *.pkg.tar.xz /app/'
+export COPY_CMD='cp *.pkg.tar.zst /app/'
 export CLEAN_CMD="rm $DEST_FILE"

--- a/distros/ArchLinux/package.sh
+++ b/distros/ArchLinux/package.sh
@@ -5,5 +5,5 @@
 if [ -n "$1" ]; then
 	export BRANCH=$1
 fi
-PKGEXT=".pkg.tar.xz"
+PKGEXT=".pkg.tar.zst"
 makepkg --clean --syncdeps --noconfirm


### PR DESCRIPTION
- Updated archlinux pkg format from old `.tar.xz` to the new standard `.tar.zst`
- fixed PKGBUILD src relative path usage