### PR TITLE
Remove the service worker cahce if any during install

### DIFF
--- a/windows/installer/windows-installer.nsi
+++ b/windows/installer/windows-installer.nsi
@@ -207,6 +207,7 @@ Section ; App Files
 
     ; Hide details
     SetDetailsPrint None
+    RMDir /r "$LOCALAPPDATA\${COMPANY_NAME}\${APP_NAME}\QtWebEngine\Default\Service Worker\CacheStorage"
 
     ;Set output path to InstallDir
     SetOutPath "$INSTDIR"


### PR DESCRIPTION
@jaruba discovered that in some cases the service worker cache from old installation may prevent Stremio to start normally. We tested that removing this directory solves the issue.