### PR TITLE
Copy all OpenSSL DLLs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ install:
   # Install OpenSSL
   - ps: $env:OPENSSL_INSTALLER = "Win32OpenSSL-1_1_1j.exe"
   - ps: Start-FileDownload "https://slproweb.com/download/$env:OPENSSL_INSTALLER"
-  - ps: Start-Process "$env:OPENSSL_INSTALLER" -ArgumentList "/silent /verysilent /sp- /suppressmsgboxes" -Wait
+  - ps: Start-Process "$env:OPENSSL_INSTALLER" -ArgumentList "/silent /verysilent /sp- /suppressmsgboxes /dir=C:\OpenSSL-Win32" -Wait
   - ps: del "$env:OPENSSL_INSTALLER"
   - set OPENSSL_BIN_PATH=C:\OpenSSL-Win32\bin
 
@@ -92,9 +92,7 @@ test_script:
   # copy-windows-mpv
   - copy "%MPV_BIN_PATH%\mpv-1.dll" dist-win
   # copy-windows-openssl
-  - copy "%OPENSSL_BIN_PATH%\libcrypto-1_1.dll" dist-win
-  - copy "%OPENSSL_BIN_PATH%\ssleay32.dll" dist-win
-  - copy "%OPENSSL_BIN_PATH%\libeay32.dll" dist-win
+  - copy "%OPENSSL_BIN_PATH%\*.dll" dist-win
   # copy-windows-ffmpeg
   - move "%FFMPEG_BIN_PATH%\ffmpeg.exe" dist-win
   # copy-windows-node (stremio-runtime)


### PR DESCRIPTION
New version of open ssl have different DLL names and although `libcrypto-1_1.dll` is there we need also `libssl-1_1.dll` in order to perform secure connections in Qt. In order to future proof this just copy all DLLs 