### PR TITLE
Fix installer for Windows and Linux

### DIFF
--- a/release.makefile
+++ b/release.makefile
@@ -13,6 +13,7 @@ ALL: ${STREMIO_BIN} ${SERVER_JS} icons
 install:
 	make -C ${BUILD_DIR} install
 	install -Dm 644 ${SERVER_JS} "${INSTALL_DIR}/server.js"
+	install -Dm 644 smartcode-stremio.desktop "${INSTALL_DIR}/smartcode-stremio.desktop"
 	cp -r icons "${INSTALL_DIR}/"
 	ln -s "${shell which node}" "${INSTALL_DIR}/node"
 ifneq ("$(wildcard ../mpv-build/mpv/build)","")

--- a/windows/installer/windows-installer.nsi
+++ b/windows/installer/windows-installer.nsi
@@ -207,6 +207,7 @@ Section ; App Files
 
     ; Hide details
     SetDetailsPrint None
+    RMDir /r "$INSTDIR"
     RMDir /r "$LOCALAPPDATA\${COMPANY_NAME}\${APP_NAME}\QtWebEngine\Default\Service Worker\CacheStorage"
 
     ;Set output path to InstallDir


### PR DESCRIPTION
On Windows delete the target directory before install so there are no old files.
On Linux copy the desktop file to the install dir.