### PR TITLE
Better error messege when initShellComm fails

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -344,8 +344,7 @@ ApplicationWindow {
             if (!err) {
                 webView.tries = 0
             } else {
-                errorDialog.text = "Error while applying shell JS." +
-                        " Please consider re-installing Stremio from https://www.stremio.com"
+                errorDialog.text = "User Interface could not be loaded.\n\nPlease try again later or contact the Stremio support team for assistance."
                 errorDialog.detailedText = err
                 errorDialog.visible = true
 


### PR DESCRIPTION
The old error message wasn't very clear so now hopefully the user will be more informed about what is going on.

![image](https://user-images.githubusercontent.com/1193870/119490831-f41fbf80-bd65-11eb-807a-a6362f64f121.png)
