### PR TITLE
add missing dependencies for debian buster

### DIFF
--- a/DEBIAN.md
+++ b/DEBIAN.md
@@ -79,7 +79,7 @@ qrc:/main.qml:12 module "Qt.labs.platform" is not installed
 
 That means you need to install:
 
-``sudo apt-get install qml-module-qtwebchannel qml-module-qt-labs-platform qml-module-qtwebengine qml-module-qtquick-dialogs qml-module-qtquick-controls qtdeclarative5-dev``
+``sudo apt-get install qml-module-qtwebchannel qml-module-qt-labs-platform qml-module-qtwebengine qml-module-qtquick-dialogs qml-module-qtquick-controls qtdeclarative5-dev qml-module-qt-labs-settings qml-module-qt-labs-folderlistmodel``
 
 Now you should be able to run it normally.
 


### PR DESCRIPTION
Closes https://github.com/Stremio/stremio-shell/issues/265

## Description

Add the following missing dependencies for the Debian Buster Installation:

- `qml-module-qt-labs-settings`
- `qml-module-qt-labs-folderlistmodel`