### PR TITLE
Add StartupWMClass

### DIFF
--- a/smartcode-stremio.desktop
+++ b/smartcode-stremio.desktop
@@ -8,3 +8,4 @@ Terminal=false
 Type=Application
 Categories=AudioVideo;Video;Player;TV;
 MimeType=application/x-bittorrent;x-scheme-handler/magnet;x-scheme-handler/stremio;video/avi;video/msvideo;video/x-msvideo;video/mp4;video/x-matroska;
+StartupWMClass=stremio


### PR DESCRIPTION
This allows docks, task managers and desktop environments to match open stremio windows to the respective launcher file. See https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html for details