### PR TITLE
GitHub removed unencrypted Git protocol.

### DIFF
--- a/DEBIAN.md
+++ b/DEBIAN.md
@@ -4,7 +4,7 @@ These instructions have been tested in Debian Buster (Testing)
 
 ## 1. Start by cloning the GIT repository:
 
-``git clone --recurse-submodules -j8 git://github.com/Stremio/stremio-shell.git``
+``git clone --recurse-submodules -j8 https://github.com/Stremio/stremio-shell.git``
 
 ## 2. Install QTCreator
 


### PR DESCRIPTION
GitHub changed its some feature for [improving Git protocol security on GitHub](https://github.blog/2021-09-01-improving-git-protocol-security-github/) on September 1, 2021. Because of that, the ``git clone`` line is needed to be updated to HTTPS or SSH. If you don't, you get some error, like so: 
```
Cloning into 'stremio-shell'...
fatal: unable to connect to github.com:
github.com[0: 140.82.121.4]: errno=Connection timed out
```