### PR TITLE
Update distro ubuntu container 20:04 to 24:04

### DIFF
--- a/distros/Ubuntu/Dockerfile
+++ b/distros/Ubuntu/Dockerfile
@@ -1,10 +1,28 @@
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 RUN ln -fs /usr/share/zoneinfo/Europe/Sofia /etc/localtime
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Install package dependencies
-RUN apt update && apt install -y git librsvg2-bin checkinstall nodejs build-essential cmake qt5-default qtdeclarative5-dev qtdeclarative5-dev-tools qtwebengine5-dev qml-module-qtquick-controls qml-module-qtquick-dialogs qml-module-qt-labs-platform qml-module-qtwebchannel qml-module-qtwebengine wget libssl-dev sudo libmpv-dev
+RUN apt update && apt install -y git \
+librsvg2-bin \
+checkinstall \
+nodejs \
+build-essential \
+cmake  \
+qtbase5-dev \
+qt5-qmake \
+qtdeclarative5-dev \
+qtdeclarative5-dev-tools \
+qtwebengine5-dev \
+qml-module-qtquick-controls \
+qml-module-qtquick-dialogs \
+qml-module-qt-labs-platform \
+qml-module-qtwebchannel \
+qml-module-qtwebengine wget \
+libssl-dev \
+sudo \
+libmpv-dev
 
 # Setting up new user
 RUN useradd builduser -m
@@ -16,4 +34,3 @@ WORKDIR /home/builduser
 ADD package.sh .
 
 RUN mkdir -p /usr/share/desktop-directories
-


### PR DESCRIPTION
Ubuntu 22.04 repository dont have qt5-default package.

You can get pre-built libraries by installing the qtbase5-dev.

https://stackoverflow.com/questions/74110674/problem-installing-qt5-default-on-ubuntu-22-04