### PR TITLE
Fix smooth scrolling in QTWEBENGINE_CHROMIUM_FLAGS

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -50,7 +50,7 @@ void InitializeParameters(QQmlApplicationEngine *engine, MainApp& app) {
 
 int main(int argc, char **argv)
 {
-    qputenv("QTWEBENGINE_CHROMIUM_FLAGS", "--autoplay-policy=no-user-gesture-required");
+    qputenv("QTWEBENGINE_CHROMIUM_FLAGS", "--autoplay-policy=no-user-gesture-required --enable-smooth-scrolling");
     #ifdef _WIN32
     // Default to ANGLE (DirectX), because that seems to eliminate so many issues on Windows
     // Also, according to the docs here: https://wiki.qt.io/Qt_5_on_Windows_ANGLE_and_OpenGL, ANGLE is also preferrable


### PR DESCRIPTION
I noticed that scrolling on the app was very rough so this is what I did:
- Updated QTWEBENGINE_CHROMIUM_FLAGS to enable smooth scrolling by default.
- Added the flag '--enable-smooth-scrolling' to improve user experience.
- Tested the enhancement and felt a smoother and more fluid scrolling experience when interacting with the app.
