### PR TITLE
Qt6 migration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.16)
 # set(CMAKE_CONFIGURATION_TYPES "Release" CACHE STRING "" FORCE)
 if(APPLE)
-  set(CMAKE_OSX_DEPLOYMENT_TARGET "10.10" CACHE STRING "Minimum OS X deployment version")
+  set(CMAKE_OSX_DEPLOYMENT_TARGET "10.14" CACHE STRING "Minimum OS X deployment version")
   set(HAVE_FLAG_SEARCH_PATHS_FIRST 0)
 endif()
 
@@ -12,7 +12,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/CMakeModules/")
 
 add_definitions(-DSTREMIO_SHELL_BIN_VERSION=${NUMERIC_VERSION} -DSTREMIO_SHELL_VERSION="${PROJECT_VERSION}"  -DUNICODE -D_UNICODE)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_AUTOMOC ON)
@@ -34,9 +34,12 @@ set(SOURCES
 )
 
 set(MPV_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/deps/libmpv/include)
+if(NOT QT_DEFAULT_MAJOR_VERSION)
+  set(QT_DEFAULT_MAJOR_VERSION 6)
+endif()
+
 if(WIN32)
   list(APPEND SOURCES stremio.rc)
-  set(QT_DEFAULT_MAJOR_VERSION 5)
   set(ENV{Qt6_DIR} $ENV{QTDIR})
   set(MPV_LIBRARY_mpv ${CMAKE_CURRENT_SOURCE_DIR}/deps/libmpv/win32/mpv.lib)
 endif()
@@ -56,7 +59,7 @@ add_subdirectory(deps/singleapplication)
 
 set(CMAKE_BUILD_RPATH_USE_ORIGIN TRUE)
 
-find_package(Qt${QT_DEFAULT_MAJOR_VERSION} COMPONENTS Widgets Network Qml Quick WebEngine WebChannel DBus OpenGL REQUIRED)
+find_package(Qt${QT_DEFAULT_MAJOR_VERSION} COMPONENTS Widgets Network Qml Quick WebEngineQuick WebChannel DBus OpenGL REQUIRED)
 find_package(OpenSSL REQUIRED)
 find_package(MPV REQUIRED)
 
@@ -109,14 +112,14 @@ target_include_directories(${PROJECT_NAME} PRIVATE
 )
 
 target_link_libraries(${PROJECT_NAME} LINK_PUBLIC
-  Qt5::Qml
-  Qt5::Quick
-  Qt5::Network
-  Qt5::Widgets
-  Qt5::WebEngine
-  Qt5::WebChannel
-  Qt5::DBus
-  Qt5::OpenGL
+  Qt${QT_DEFAULT_MAJOR_VERSION}::Qml
+  Qt${QT_DEFAULT_MAJOR_VERSION}::Quick
+  Qt${QT_DEFAULT_MAJOR_VERSION}::Network
+  Qt${QT_DEFAULT_MAJOR_VERSION}::Widgets
+  Qt${QT_DEFAULT_MAJOR_VERSION}::WebEngineQuick
+  Qt${QT_DEFAULT_MAJOR_VERSION}::WebChannel
+  Qt${QT_DEFAULT_MAJOR_VERSION}::DBus
+  Qt${QT_DEFAULT_MAJOR_VERSION}::OpenGL
   SingleApplication::SingleApplication
   OpenSSL::Crypto
   ${MPV_LIBRARY}

--- a/DEBIAN.md
+++ b/DEBIAN.md
@@ -1,96 +1,58 @@
 # Build Stremio for Debian GNU/Linux
 
-These instructions have been tested in Debian Bookworm 12 (Stable)
+These instructions have been tested on Debian Trixie 13 and Sid (unstable).
 
-## 1. Start by cloning the GIT repository:
+## 1. Clone the repository
 
-``git clone --recurse-submodules -j8 https://github.com/Stremio/stremio-shell.git``
-
-## 2. Install QTCreator and other dependencies
-
-``sudo apt-get install qtcreator qt5-qmake g++ pkgconf libssl-dev librsvg2-bin``
-
-## 3. Generate the Makefiles for Stremio
-
-``cd stremio-shell``
-
-``qmake``
-
-## 3.1 Install missing dependencies
-
-If you see this message:
-
-```
-Info: creating stash file /home/mendezr/development/misc/stremio-shell/.qmake.stash
-Project ERROR: mpv development package not found
+```bash
+git clone --recurse-submodules https://github.com/vejeta/stremio-shell.git
+cd stremio-shell
+git checkout qt6-migration
 ```
 
-Then you need to install the development package for mpv (movie player)
+If you already cloned without `--recurse-submodules`:
 
-``sudo apt-get install libmpv-dev``
-
-If you see this message:
-
-```
-Project ERROR: Unknown module(s) in QT: qml quick webengine
+```bash
+git submodule update --init
 ```
 
-Then install:
-``sudo apt-get install libqt5webview5-dev``
+## 2. Install build dependencies
 
-If you find:
-```Project ERROR: Unknown module(s) in QT: webengine```
+```bash
+sudo apt-get install cmake g++ pkgconf libssl-dev libmpv-dev librsvg2-bin \
+  qt6-base-dev qt6-declarative-dev qt6-webengine-dev qt6-webchannel-dev qt6-tools-dev libgl-dev
+```
 
-Then install:
+## 3. Build Stremio
 
-``sudo apt-get install libkf5webengineviewer-dev``
+```bash
+mkdir build && cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release -DQT_DEFAULT_MAJOR_VERSION=6
+make -j$(nproc)
+```
 
-## 4. Compile Stremio:
+## 4. Install runtime QML dependencies
 
-$ make -f release.makefile
+If you see errors like `module "QtWebEngine" is not installed` when running, install:
 
-This will create a new directory named `build` where the `stremio' binary will be located. It will also generate icons and download the streaming server.
-
+```bash
+sudo apt-get install qml6-module-qtwebengine qml6-module-qtwebchannel \
+  qml6-module-qtquick-controls qml6-module-qtquick-dialogs
+```
 
 ## 5. Prepare the streaming server
 
-Upon running the ./build/stremio binary, stremio should start up as usual. Except it won't start the streaming server, for this you need to have NodeJS installed and server.js in your working dir, for which you need to do:
+The stremio binary expects a Node.js server in the same directory:
 
-``cp ./server.js ./build/ && ln -s "$(which node)" ./build/node``
-
-
-## 6. Install other dependencies
-
-If you get this messages:
-
-```
-$ ./stremio
-QQmlApplicationEngine failed to load component
-qrc:/main.qml:3 module "QtWebChannel" is not installed
-qrc:/main.qml:2 module "QtWebEngine" is not installed
-qrc:/main.qml:12 module "Qt.labs.platform" is not installed
-qrc:/main.qml:3 module "QtWebChannel" is not installed
-qrc:/main.qml:2 module "QtWebEngine" is not installed
-qrc:/main.qml:12 module "Qt.labs.platform" is not installed
-qrc:/main.qml:3 module "QtWebChannel" is not installed
-qrc:/main.qml:2 module "QtWebEngine" is not installed
-qrc:/main.qml:12 module "Qt.labs.platform" is not installed
+```bash
+cp ./server.js ./build/
+ln -s "$(which node)" ./build/node
 ```
 
-That means you need to install:
+## 6. Run Stremio
 
-``sudo apt-get install qml-module-qtwebchannel qml-module-qt-labs-platform qml-module-qtwebengine qml-module-qtquick-dialogs qml-module-qtquick-controls qtdeclarative5-dev qml-module-qt-labs-settings qml-module-qt-labs-folderlistmodel``
+```bash
+./build/stremio
+```
 
-Now you should be able to run it normally.
-
-## 7. Run Stremio
-
-``./build/stremio``
-
-If you get a popup window stating:
-
-Error while starting streaming server. Please consider re-installing Stremio from https://www.stremio.com
-
-Perhaps you've skipped step #5
-
-Cheers! 
+If you get a popup about the streaming server failing, make sure you completed step 5.

--- a/README.md
+++ b/README.md
@@ -1,47 +1,42 @@
 ## Build
 
-### Build instructions for Mac OS X
+This branch (`qt6-migration`) uses **Qt 6** and **CMake** as the build system.
 
-1. Make sure you have Qt 5.10.x or newer and Qt Creator
-2. Open the project in Qt creator
-3. build it
+### Dependencies
 
-#### Command line to build:
-
+**Debian/Ubuntu:**
+```bash
+sudo apt install qt6-base-dev qt6-declarative-dev qt6-webengine-dev \
+  qt6-webchannel-dev qt6-tools-dev libgl-dev libmpv-dev libssl-dev cmake
 ```
-qmake
-make
+
+### Build instructions (all platforms)
+
+```bash
+# Clone with submodules
+git clone --recurse-submodules https://github.com/vejeta/stremio-shell.git
+cd stremio-shell
+git checkout qt6-migration
+
+# If you already cloned without --recurse-submodules:
+git submodule update --init
+
+# Build
+mkdir build && cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release -DQT_DEFAULT_MAJOR_VERSION=6
+make -j$(nproc)
 ```
-### Build instructions for Windows
 
-Please, refer to [WINDOWS.md](https://github.com/Stremio/stremio-shell/blob/master/WINDOWS.md) for a detailed explanation of how to build the latest Stremio in Windows.
+### Platform-specific notes
 
-
-### Build instructions for Debian GNU/Linux
-
-Please, refer to [DEBIAN.md](https://github.com/Stremio/stremio-shell/blob/master/DEBIAN.md) for a detailed explanation of how to build the latest Stremio in Debian.
-
-### Build instructions for OpenSuseLeap 15.0
-
-Please, refer to [OpenSuseLeap.md](https://github.com/Stremio/stremio-shell/blob/master/OpenSuseLeap.md) for a detailed explanation of how to build the latest Stremio in OpenSuseLeap 15.0
-
-### Build instructions for Docker builds of supported Linux distros
-
-There are Docker files and setup scripts for supported Linux distributions (Debian, Fedora, Arch), located in the `./distros` directory.
-
-There is also an automated build script located in `./dist-utils/build-package.sh`.
-
-For more information refer to the [DOCKER.md](DOCKER.md) file.
-
-## Third-party install scripts
-
-There are repositories for third-party install scripts that may be useful for you, most notably: https://github.com/alexandru-balan/Stremio-Install-Scripts
-
-We give no guarantees about their correctness or security.
+- **Windows**: Refer to [WINDOWS.md](WINDOWS.md)
+- **Debian**: Refer to [DEBIAN.md](DEBIAN.md)
+- **OpenSuse Leap**: Refer to [OpenSuseLeap.md](OpenSuseLeap.md)
+- **Docker**: See `./distros` directory and [DOCKER.md](DOCKER.md)
 
 ## Releasing a version
 
-1. Bump the version in the `stremio.pro` file
+1. Bump the version in `CMakeLists.txt`
 2. Create a git tag with the corresponding version
 
 ## Arguments

--- a/autoupdater.h
+++ b/autoupdater.h
@@ -15,9 +15,8 @@
 #include <QUrlQuery>
 #include <QProcessEnvironment>
 #include <QQueue>
-#include <QVector>
+#include <QList>
 #include <QProcess>
-#include <QNetworkConfigurationManager>
 
 // Mixing C and C++ :(
 extern "C" {

--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,5 @@
 #include <QQmlApplicationEngine>
-#include <QtWebEngine>
-#include <QSysInfo>
+#include <QtWebEngineQuick>
 
 #include <clocale>
 
@@ -50,25 +49,9 @@ void InitializeParameters(QQmlApplicationEngine *engine, MainApp& app) {
 int main(int argc, char **argv)
 {
     qputenv("QTWEBENGINE_CHROMIUM_FLAGS", "--autoplay-policy=no-user-gesture-required");
-    #ifdef _WIN32
-    // Default to ANGLE (DirectX), because that seems to eliminate so many issues on Windows
-    // Also, according to the docs here: https://wiki.qt.io/Qt_5_on_Windows_ANGLE_and_OpenGL, ANGLE is also preferrable
-    // We do not need advanced OpenGL features but we need more universal support
 
-    Application::setAttribute(Qt::AA_UseOpenGLES);
-    auto winVer = QSysInfo::windowsVersion();
-    if(winVer <= QSysInfo::WV_WINDOWS8 && winVer != QSysInfo::WV_None) {
-        qputenv("NODE_SKIP_PLATFORM_CHECK", "1");
-    }
-    if(winVer <= QSysInfo::WV_WINDOWS7 && winVer != QSysInfo::WV_None) {
-        qputenv("QT_ANGLE_PLATFORM", "d3d9");
-    }
-    #endif
-
-    // This is really broken on Linux
-    #ifndef Q_OS_LINUX
-    Application::setAttribute(Qt::AA_EnableHighDpiScaling);
-    #endif
+    // Qt6: QtWebEngineQuick::initialize() must be called before QApplication
+    QtWebEngineQuick::initialize();
 
     Application::setApplicationName("Stremio");
     Application::setApplicationVersion(STREMIO_SHELL_VERSION);

--- a/main.cpp
+++ b/main.cpp
@@ -1,5 +1,6 @@
 #include <QQmlApplicationEngine>
 #include <QtWebEngineQuick>
+#include <QQuickWindow>
 
 #include <clocale>
 
@@ -49,6 +50,10 @@ void InitializeParameters(QQmlApplicationEngine *engine, MainApp& app) {
 int main(int argc, char **argv)
 {
     qputenv("QTWEBENGINE_CHROMIUM_FLAGS", "--autoplay-policy=no-user-gesture-required");
+
+    // Qt6: Force OpenGL backend for QQuickFramebufferObject (used by MPV renderer).
+    // Without this, Qt6 RHI may choose Vulkan/Metal and MPV frames won't update.
+    QQuickWindow::setGraphicsApi(QSGRendererInterface::OpenGL);
 
     // Qt6: QtWebEngineQuick::initialize() must be called before QApplication
     QtWebEngineQuick::initialize();

--- a/main.qml
+++ b/main.qml
@@ -446,7 +446,7 @@ ApplicationWindow {
         // In the app, we use open-external IPC signal, but make sure this works anyway
         property string hoveredUrl: ""
         onLinkHovered: function(url) { webView.hoveredUrl = url }
-        onNewViewRequested: function(req) { if (req.userInitiated) Qt.openUrlExternally(webView.hoveredUrl) }
+        onNewWindowRequested: function(req) { if (req.userInitiated) Qt.openUrlExternally(webView.hoveredUrl) }
 
         // FIXME: When is this called?
         onFullScreenRequested: function(req) {

--- a/main.qml
+++ b/main.qml
@@ -281,7 +281,7 @@ ApplicationWindow {
         errorDialog.detailedText = 'Stremio streaming server has thrown an error \nQProcess::ProcessError code: ' 
             + code + '\n\n' 
             + streamingServer.getErrBuff();
-        errorDialog.visible = true
+        errorDialog.open()
     }
     function launchServer() {
         var node_executable = applicationDirPath + "/node"
@@ -356,7 +356,7 @@ ApplicationWindow {
             } else {
                 errorDialog.text = "User Interface could not be loaded.\n\nPlease try again later or contact the Stremio support team for assistance."
                 errorDialog.detailedText = err
-                errorDialog.visible = true
+                errorDialog.open()
 
                 console.error(err)
             }
@@ -561,8 +561,6 @@ ApplicationWindow {
     MessageDialog {
         id: errorDialog
         title: "Stremio - Application Error"
-        property string detailedText: ""
-        informativeText: detailedText
         buttons: MessageDialog.Ok
     }
 

--- a/main.qml
+++ b/main.qml
@@ -1,14 +1,15 @@
-import QtQuick 2.7
-import QtWebEngine 1.4
-import QtWebChannel 1.0
-import QtQuick.Window 2.2 // for Window instead of ApplicationWindow; also for Screen
-import QtQuick.Controls 1.4 // for ApplicationWindow
-import QtQuick.Dialogs 1.2
+import QtQuick
+import QtWebEngine
+import QtWebChannel
+import QtQuick.Window
+import QtQuick.Controls
+import QtQuick.Dialogs
 import com.stremio.process 1.0
 import com.stremio.screensaver 1.0
 import com.stremio.libmpv 1.0
 import com.stremio.clipboard 1.0
-import QtQml 2.2
+import QtQml
+import QtCore
 
 import "autoupdater.js" as Autoupdater
 
@@ -98,18 +99,23 @@ ApplicationWindow {
             if (ev === "file-close") fileDialog.close()
             if (ev === "file-open") {
               if (typeof args !== "undefined") {
-                var fileDialogDefaults = {
-                  title: "Please choose",
-                  selectExisting: true,
-                  selectFolder: false,
-                  selectMultiple: false,
-                  nameFilters: [],
-                  selectedNameFilter: "",
-                  data: null
+                fileDialog.title = args.hasOwnProperty("title") ? args.title : "Please choose"
+                fileDialog.selectExisting = args.hasOwnProperty("selectExisting") ? args.selectExisting : true
+                fileDialog.selectFolder = args.hasOwnProperty("selectFolder") ? args.selectFolder : false
+                fileDialog.selectMultiple = args.hasOwnProperty("selectMultiple") ? args.selectMultiple : false
+                fileDialog.nameFilters = args.hasOwnProperty("nameFilters") ? args.nameFilters : []
+                fileDialog.data = args.hasOwnProperty("data") ? args.data : null
+
+                // Map legacy properties to Qt6 fileMode
+                if (fileDialog.selectFolder) {
+                  fileDialog.fileMode = FileDialog.OpenFolder
+                } else if (fileDialog.selectMultiple) {
+                  fileDialog.fileMode = FileDialog.OpenFiles
+                } else if (fileDialog.selectExisting) {
+                  fileDialog.fileMode = FileDialog.OpenFile
+                } else {
+                  fileDialog.fileMode = FileDialog.SaveFile
                 }
-                Object.keys(fileDialogDefaults).forEach(function(key) {
-                  fileDialog[key] = args.hasOwnProperty(key) ? args[key] : fileDialogDefaults[key]
-                })
               }
               fileDialog.open()
             }
@@ -439,7 +445,7 @@ ApplicationWindow {
 
         // In the app, we use open-external IPC signal, but make sure this works anyway
         property string hoveredUrl: ""
-        onLinkHovered: webView.hoveredUrl = hoveredUrl
+        onLinkHovered: function(url) { webView.hoveredUrl = url }
         onNewViewRequested: function(req) { if (req.userInitiated) Qt.openUrlExternally(webView.hoveredUrl) }
 
         // FIXME: When is this called?
@@ -461,34 +467,34 @@ ApplicationWindow {
 
         Menu {
             id: ctxMenu
-            MenuItem {
+            Action {
                 text: "Undo"
                 shortcut: StandardKey.Undo
                 onTriggered: webView.triggerWebAction(WebEngineView.Undo)
             }
-            MenuItem {
+            Action {
                 text: "Redo"
                 shortcut: StandardKey.Redo
                 onTriggered: webView.triggerWebAction(WebEngineView.Redo)
             }
             MenuSeparator { }
-            MenuItem {
+            Action {
                 text: "Cut"
                 shortcut: StandardKey.Cut
                 onTriggered: webView.triggerWebAction(WebEngineView.Cut)
             }
-            MenuItem {
+            Action {
                 text: "Copy"
                 shortcut: StandardKey.Copy
                 onTriggered: webView.triggerWebAction(WebEngineView.Copy)
             }
-            MenuItem {
+            Action {
                 text: "Paste"
                 shortcut: StandardKey.Paste
                 onTriggered: webView.triggerWebAction(WebEngineView.Paste)
             }
             MenuSeparator { }
-            MenuItem {
+            Action {
                 text: "Select All"
                 shortcut: StandardKey.SelectAll
                 onTriggered: webView.triggerWebAction(WebEngineView.SelectAll)
@@ -504,9 +510,9 @@ ApplicationWindow {
             }
         }
 
-        Action {
-            shortcut: StandardKey.Paste
-            onTriggered: webView.triggerWebAction(WebEngineView.Paste)
+        Shortcut {
+            sequence: StandardKey.Paste
+            onActivated: webView.triggerWebAction(WebEngineView.Paste)
         }
 
         DropArea {
@@ -555,19 +561,26 @@ ApplicationWindow {
     MessageDialog {
         id: errorDialog
         title: "Stremio - Application Error"
-        // onAccepted handler does not work
-        //icon: StandardIcon.Critical
-        //standardButtons: StandardButton.Ok
+        property string detailedText: ""
+        informativeText: detailedText
+        buttons: MessageDialog.Ok
     }
 
     FileDialog {
       id: fileDialog
-      folder: shortcuts.home
+      currentFolder: StandardPaths.writableLocation(StandardPaths.HomeLocation)
+      // Qt6 FileDialog properties for compatibility with the transport event API
+      property bool selectExisting: true
+      property bool selectFolder: false
+      property bool selectMultiple: false
+      property var data: {}
       onAccepted: {
         var fileProtocol = "file://"
         var onWindows = Qt.platform.os === "windows" ? 1 : 0
         var pathSeparators = ["/", "\\"]
-        var files = fileDialog.fileUrls.filter(function(fileUrl) {
+        var files = fileDialog.selectedFiles.map(function(fileUrl) {
+          return fileUrl.toString()
+        }).filter(function(fileUrl) {
           // Ignore network drives and alike
           return fileUrl.startsWith(fileProtocol)
         })
@@ -584,7 +597,7 @@ ApplicationWindow {
           selectFolder: fileDialog.selectFolder,
           selectMultiple: fileDialog.selectMultiple,
           nameFilters: fileDialog.nameFilters,
-          selectedNameFilter: fileDialog.selectedNameFilter,
+          selectedNameFilter: fileDialog.selectedNameFilterIndex,
           data: fileDialog.data
         })
       }
@@ -595,11 +608,10 @@ ApplicationWindow {
           selectFolder: fileDialog.selectFolder,
           selectMultiple: fileDialog.selectMultiple,
           nameFilters: fileDialog.nameFilters,
-          selectedNameFilter: fileDialog.selectedNameFilter,
+          selectedNameFilter: fileDialog.selectedNameFilterIndex,
           data: fileDialog.data
         })
       }
-      property var data: {}
     }
 
     //

--- a/main.qml
+++ b/main.qml
@@ -104,7 +104,7 @@ ApplicationWindow {
                 fileDialog.selectFolder = args.hasOwnProperty("selectFolder") ? args.selectFolder : false
                 fileDialog.selectMultiple = args.hasOwnProperty("selectMultiple") ? args.selectMultiple : false
                 fileDialog.nameFilters = args.hasOwnProperty("nameFilters") ? args.nameFilters : []
-                fileDialog.data = args.hasOwnProperty("data") ? args.data : null
+                fileDialog.extraData = args.hasOwnProperty("data") ? args.data : null
 
                 // Map legacy properties to Qt6 fileMode
                 if (fileDialog.selectFolder) {
@@ -571,7 +571,7 @@ ApplicationWindow {
       property bool selectExisting: true
       property bool selectFolder: false
       property bool selectMultiple: false
-      property var data: {}
+      property var extraData: null
       onAccepted: {
         var fileProtocol = "file://"
         var onWindows = Qt.platform.os === "windows" ? 1 : 0
@@ -596,7 +596,7 @@ ApplicationWindow {
           selectMultiple: fileDialog.selectMultiple,
           nameFilters: fileDialog.nameFilters,
           selectedNameFilter: fileDialog.selectedNameFilterIndex,
-          data: fileDialog.data
+          data: fileDialog.extraData
         })
       }
       onRejected: {
@@ -607,7 +607,7 @@ ApplicationWindow {
           selectMultiple: fileDialog.selectMultiple,
           nameFilters: fileDialog.nameFilters,
           selectedNameFilter: fileDialog.selectedNameFilterIndex,
-          data: fileDialog.data
+          data: fileDialog.extraData
         })
       }
     }

--- a/mpv.cpp
+++ b/mpv.cpp
@@ -9,7 +9,7 @@
 #include <QtGlobal>
 #include <QOpenGLContext>
 
-#include <QtGui/QOpenGLFramebufferObject>
+#include <QOpenGLFramebufferObject>
 
 #include <QtQuick/QQuickWindow>
 #include <QtQuick/QQuickView>
@@ -81,8 +81,6 @@ class MpvRenderer : public QQuickFramebufferObject::Renderer
 
     void render()
     {
-        obj->window()->resetOpenGLState();
-
         QOpenGLFramebufferObject *fbo = framebufferObject();
         mpv_opengl_fbo mpfbo{static_cast<int>(fbo->handle()), fbo->width(), fbo->height(), 0};
         int flip_y{0};
@@ -99,8 +97,6 @@ class MpvRenderer : public QQuickFramebufferObject::Renderer
         // See render_gl.h on what OpenGL environment mpv expects, and
         // other API details.
         mpv_render_context_render(obj->mpv_gl, params);
-
-        obj->window()->resetOpenGLState();
      }
 };
 
@@ -308,7 +304,6 @@ QVariant MpvObject::getProperty(const QString& name) {
 }
 QQuickFramebufferObject::Renderer *MpvObject::createRenderer() const
 {
-    window()->setPersistentOpenGLContext(true);
-    window()->setPersistentSceneGraph(true);
+    // Qt6: persistent OpenGL context and scene graph are the default behavior
     return new MpvRenderer(const_cast<MpvObject *>(this));
 }

--- a/mpv.cpp
+++ b/mpv.cpp
@@ -182,6 +182,8 @@ void MpvObject::on_update(void *ctx)
 void MpvObject::doUpdate()
 {
     update();
+    if (window())
+        window()->update();
 }
 
 void MpvObject::command(const QVariant& params)
@@ -300,6 +302,7 @@ QVariant MpvObject::getProperty(const QString& name) {
 }
 QQuickFramebufferObject::Renderer *MpvObject::createRenderer() const
 {
-    // Qt6: persistent OpenGL context and scene graph are the default behavior
+    window()->setPersistentGraphics(true);
+    window()->setPersistentSceneGraph(true);
     return new MpvRenderer(const_cast<MpvObject *>(this));
 }

--- a/mpv.cpp
+++ b/mpv.cpp
@@ -86,17 +86,13 @@ class MpvRenderer : public QQuickFramebufferObject::Renderer
         int flip_y{0};
 
         mpv_render_param params[] = {
-            // Specify the default framebuffer (0) as target. This will
-            // render onto the entire screen. If you want to show the video
-            // in a smaller rectangle or apply fancy transformations, you'll
-            // need to render into a separate FBO and draw it manually.
             {MPV_RENDER_PARAM_OPENGL_FBO, &mpfbo},
-            // Flip rendering (needed due to flipped GL coordinate system).
             {MPV_RENDER_PARAM_FLIP_Y, &flip_y},
             {MPV_RENDER_PARAM_INVALID, nullptr}};
-        // See render_gl.h on what OpenGL environment mpv expects, and
-        // other API details.
+
+        obj->window()->beginExternalCommands();
         mpv_render_context_render(obj->mpv_gl, params);
+        obj->window()->endExternalCommands();
      }
 };
 

--- a/mpv.cpp
+++ b/mpv.cpp
@@ -11,6 +11,7 @@
 
 #include <QOpenGLFramebufferObject>
 
+#include <QGuiApplication>
 #include <QtQuick/QQuickWindow>
 #include <QtQuick/QQuickView>
 
@@ -66,9 +67,23 @@ class MpvRenderer : public QQuickFramebufferObject::Renderer
         if (!obj->mpv_gl)
         {
             mpv_opengl_init_params gl_init_params{get_proc_address_mpv, nullptr, nullptr};
+
+            mpv_render_param display{MPV_RENDER_PARAM_INVALID, nullptr};
+#if defined(Q_OS_UNIX) && !defined(Q_OS_DARWIN)
+            if (QGuiApplication::platformName() == QStringLiteral("xcb")) {
+                display.type = MPV_RENDER_PARAM_X11_DISPLAY;
+                display.data = qGuiApp->nativeInterface<QNativeInterface::QX11Application>()->display();
+            }
+            if (QGuiApplication::platformName() == QStringLiteral("wayland")) {
+                display.type = MPV_RENDER_PARAM_WL_DISPLAY;
+                display.data = qGuiApp->nativeInterface<QNativeInterface::QWaylandApplication>()->display();
+            }
+#endif
+
             mpv_render_param params[]{
                 {MPV_RENDER_PARAM_API_TYPE, const_cast<char *>(MPV_RENDER_API_TYPE_OPENGL)},
                 {MPV_RENDER_PARAM_OPENGL_INIT_PARAMS, &gl_init_params},
+                display,
                 {MPV_RENDER_PARAM_INVALID, nullptr}};
 
             if (mpv_render_context_create(&obj->mpv_gl, obj->mpv, params) < 0)
@@ -90,9 +105,7 @@ class MpvRenderer : public QQuickFramebufferObject::Renderer
             {MPV_RENDER_PARAM_FLIP_Y, &flip_y},
             {MPV_RENDER_PARAM_INVALID, nullptr}};
 
-        obj->window()->beginExternalCommands();
         mpv_render_context_render(obj->mpv_gl, params);
-        obj->window()->endExternalCommands();
      }
 };
 
@@ -182,8 +195,6 @@ void MpvObject::on_update(void *ctx)
 void MpvObject::doUpdate()
 {
     update();
-    if (window())
-        window()->update();
 }
 
 void MpvObject::command(const QVariant& params)
@@ -302,7 +313,5 @@ QVariant MpvObject::getProperty(const QString& name) {
 }
 QQuickFramebufferObject::Renderer *MpvObject::createRenderer() const
 {
-    window()->setPersistentGraphics(true);
-    window()->setPersistentSceneGraph(true);
     return new MpvRenderer(const_cast<MpvObject *>(this));
 }

--- a/screensaver.cpp
+++ b/screensaver.cpp
@@ -14,9 +14,7 @@ static QDBusInterface screenSaverInterface("org.freedesktop.ScreenSaver",
 #endif //Q_OS_MAC
 #ifdef Q_OS_WIN
 #include <QAbstractEventDispatcher>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QAbstractNativeEventFilter>
-#endif
 //mingw gcc4.4 EXECUTION_STATE
 #ifdef __MINGW32__
 #ifndef _WIN32_WINDOWS
@@ -27,10 +25,7 @@ static QDBusInterface screenSaverInterface("org.freedesktop.ScreenSaver",
 #define USE_NATIVE_EVENT 0
 
 #if USE_NATIVE_EVENT
-class ScreenSaverEventFilter
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-        : public QAbstractNativeEventFilter
-#endif
+class ScreenSaverEventFilter : public QAbstractNativeEventFilter
 {
 public:
     //screensaver is global
@@ -40,41 +35,27 @@ public:
     }
     void enable(bool yes = true) {
         if (!yes) {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-            mLastEventFilter = QAbstractEventDispatcher::instance()->setEventFilter(eventFilter);
-#else
             QAbstractEventDispatcher::instance()->installNativeEventFilter(this);
-#endif
         } else {
             if (!QAbstractEventDispatcher::instance())
                 return;
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-            mLastEventFilter = QAbstractEventDispatcher::instance()->setEventFilter(mLastEventFilter);
-#else
             QAbstractEventDispatcher::instance()->removeNativeEventFilter(this);
-#endif
         }
     }
     void disable(bool yes = true) {
         enable(!yes);
     }
 
-    bool nativeEventFilter(const QByteArray &eventType, void *message, long *result) {
+    bool nativeEventFilter(const QByteArray &eventType, void *message, qintptr *result) {
         Q_UNUSED(eventType);
         MSG* msg = static_cast<MSG*>(message);
-        //qDebug("ScreenSaverEventFilter: %p", msg->message);
         if (WM_DEVICECHANGE == msg->message) {
             qDebug("~~~~~~~~~~device event");
-            /*if (msg->wParam == DBT_DEVICEREMOVECOMPLETE) {
-                qDebug("Remove device");
-            }*/
-
         }
         if (msg->message == WM_SYSCOMMAND
                 && ((msg->wParam & 0xFFF0) == SC_SCREENSAVE
                     || (msg->wParam & 0xFFF0) == SC_MONITORPOWER)
         ) {
-            //qDebug("WM_SYSCOMMAND SC_SCREENSAVE SC_MONITORPOWER");
             if (result) {
                 //*result = 0; //why crash?
             }
@@ -85,16 +66,7 @@ public:
 private:
     ScreenSaverEventFilter() {}
     ~ScreenSaverEventFilter() {}
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-    static QAbstractEventDispatcher::EventFilter mLastEventFilter;
-    static bool eventFilter(void* message) {
-        return ScreenSaverEventFilter::instance().nativeEventFilter("windows_MSG", message, 0);
-    }
-#endif
 };
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-QAbstractEventDispatcher::EventFilter ScreenSaverEventFilter::mLastEventFilter = 0;
-#endif
 #endif //USE_NATIVE_EVENT
 #endif //Q_OS_WIN
 

--- a/stremio.pro
+++ b/stremio.pro
@@ -11,7 +11,7 @@ QMAKE_TARGET_BUNDLE_PREFIX = com.smartcodeltd
 QMAKE_INFO_PLIST = Info.plist
 
 QT += qml quick network
-CONFIG += c++11
+CONFIG += c++17
 
 include(deps/singleapplication/singleapplication.pri)
 DEFINES += QAPPLICATION_CLASS=QApplication
@@ -58,7 +58,7 @@ win32{
 QT += widgets
 
 # TODO: if def WEBENGINE
-QT += webengine webchannel dbus
+QT += webenginequick webchannel dbus
 WEBENGINE_CONFIG+=use_proprietary_codecs
 
 SOURCES += main.cpp \

--- a/stremioprocess.cpp
+++ b/stremioprocess.cpp
@@ -56,6 +56,21 @@ void Process::start(const QString &program, const QVariantList &arguments, QStri
     QObject::connect(this, &QProcess::readyReadStandardError, this, &Process::onStdErr);
     QObject::connect(this, &QProcess::started, this, &Process::onStarted);
 
+    // Ensure essential environment variables are available to spawned processes.
+    // QProcess may not inherit the full environment; Node.js server.js requires
+    // HOME, USER, and PWD for path.join() operations on cache directories.
+    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+    if (!env.contains("HOME")) {
+        env.insert("HOME", QStandardPaths::writableLocation(QStandardPaths::HomeLocation));
+    }
+    if (!env.contains("USER")) {
+        env.insert("USER", qgetenv("USER"));
+    }
+    if (!env.contains("PWD")) {
+        env.insert("PWD", QDir::currentPath());
+    }
+    this->setProcessEnvironment(env);
+
     QProcess::start(program, args);
 }
 

--- a/stremioprocess.h
+++ b/stremioprocess.h
@@ -1,9 +1,11 @@
 #ifndef STREMIOPROCESS_H
 #define STREMIOPROCESS_H
 #include <QProcess>
+#include <QProcessEnvironment>
 #include <QVariant>
 #include <QStandardPaths>
 #include <QObject>
+#include <QDir>
 #include <iostream>
 
 class Process : public QProcess {


### PR DESCRIPTION
Qt5 reached end-of-life. This migrates stremio-shell to Qt6 with minimal changes                                                                                                                                                      , mostly removing deprecated code).
                                                                                                                                                                                                                                             
### Summary     
  - **Build:** CMake 3.16+, C++17, `WebEngine` → `WebEngineQuick`                                                                                                                                                                            
  - **Core:** `QtWebEngineQuick::initialize()`, versionless QML imports, Controls 2                                                                                                                                                          
  - **Cleanup:** Remove deprecated Qt5 attributes, Qt4 compat guards, `QNetworkConfigurationManager`                                                                                                                                         
  - **Fix:** MPV FBO include path, QProcess environment for Node.js server                                                                                                                                                                   
                                                                                                                                                                                                                                             
Tested on Debian sid (Qt 6.8) — builds, runs, streams, and plays back correctly.                                                                                                                                                           
                  
Related to #442                            