### PR TITLE
Add MPRIS2 support on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,10 @@ if(WIN32)
   set(MPV_LIBRARY_mpv ${CMAKE_CURRENT_SOURCE_DIR}/deps/libmpv/win32/mpv.lib)
 endif()
 
+if(UNIX AND NOT APPLE)
+  list(APPEND SOURCES mpris.cpp)
+endif()
+
 if(APPLE)
   list(APPEND SOURCES images/stremio.icns)
   set_source_files_properties(images/stremio.icns PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")

--- a/main.cpp
+++ b/main.cpp
@@ -118,7 +118,7 @@ int main(int argc, char **argv)
             if (mpv) {
                 mprisSetup(mpv);
             } else {
-                qWarning("MPRIS: MpvObject não encontrado na árvore QML");
+                qWarning("MPRIS: MpvObject not found in QML object tree");
             }
         }
     }

--- a/main.cpp
+++ b/main.cpp
@@ -25,6 +25,10 @@ typedef QApplication Application;
 #include "screensaver.h"
 #include "qclipboardproxy.h"
 
+#ifdef Q_OS_LINUX
+#include "mpris.h"
+#endif
+
 #else
 #include <QGuiApplication>
 #endif
@@ -105,6 +109,20 @@ int main(int argc, char **argv)
     InitializeParameters(engine, app); 
 
     engine->load(QUrl(QStringLiteral("qrc:/main.qml")));
+
+#ifdef Q_OS_LINUX
+    {
+        QObject *root = engine->rootObjects().value(0);
+        if (root) {
+            MpvObject *mpv = root->findChild<MpvObject*>();
+            if (mpv) {
+                mprisSetup(mpv);
+            } else {
+                qWarning("MPRIS: MpvObject não encontrado na árvore QML");
+            }
+        }
+    }
+#endif
 
     #ifndef Q_OS_MACOS
     QObject::connect( &app, &SingleApplication::receivedMessage, &app, &MainApp::processMessage );

--- a/mpris.cpp
+++ b/mpris.cpp
@@ -1,0 +1,181 @@
+#include "mpris.h"
+
+#include <QtQuick/QQuickItem>
+#include <QtQuick/QQuickWindow>
+#include <QJsonObject>
+
+static const char *MPRIS_OBJECT_PATH = "/org/mpris/MediaPlayer2";
+static const char *PLAYER_IFACE      = "org.mpris.MediaPlayer2.Player";
+static const char *SERVICE_NAME      = "org.mpris.MediaPlayer2.stremio";
+
+// ─── MprisRootAdaptor ─────────────────────────────────────────────────────────
+
+MprisRootAdaptor::MprisRootAdaptor(QObject *parent)
+    : QDBusAbstractAdaptor(parent)
+{}
+
+void MprisRootAdaptor::Raise()
+{
+    QQuickItem *item = qobject_cast<QQuickItem *>(parent());
+    if (!item) return;
+    QWindow *win = item->window();
+    if (win) {
+        win->show();
+        win->raise();
+        win->requestActivate();
+    }
+}
+
+// ─── MprisPlayerAdaptor ───────────────────────────────────────────────────────
+
+MprisPlayerAdaptor::MprisPlayerAdaptor(MpvObject *player)
+    : QDBusAbstractAdaptor(player), m_player(player)
+{
+    // Observa as propriedades mpv relevantes para MPRIS
+    player->observeProperty("core-idle");
+    player->observeProperty("pause");
+    player->observeProperty("media-title");
+    player->observeProperty("duration");
+    player->observeProperty("volume");
+
+    connect(player, &MpvObject::mpvEvent,
+            this,   &MprisPlayerAdaptor::onMpvEvent);
+}
+
+QString MprisPlayerAdaptor::playbackStatus() const
+{
+    if (m_idle)   return "Stopped";
+    if (m_paused) return "Paused";
+    return "Playing";
+}
+
+QVariantMap MprisPlayerAdaptor::metadata() const
+{
+    QVariantMap map;
+    map["mpris:trackid"] = QVariant::fromValue(
+        QDBusObjectPath("/org/stremio/track/0")
+    );
+    if (!m_title.isEmpty())
+        map["xesam:title"] = m_title;
+    if (m_duration > 0.0)
+        map["mpris:length"] = qlonglong(m_duration * 1e6);
+    return map;
+}
+
+double MprisPlayerAdaptor::volume() const
+{
+    return m_player->getProperty("volume").toDouble() / 100.0;
+}
+
+void MprisPlayerAdaptor::setVolume(double v)
+{
+    m_player->setProperty("volume", v * 100.0);
+    emitPropertiesChanged({{"Volume", v}});
+}
+
+qlonglong MprisPlayerAdaptor::position() const
+{
+    return qlonglong(m_player->getProperty("time-pos").toDouble() * 1e6);
+}
+
+void MprisPlayerAdaptor::PlayPause()
+{
+    m_player->command(QVariantList() << "cycle" << "pause");
+}
+
+void MprisPlayerAdaptor::Play()
+{
+    m_player->setProperty("pause", false);
+}
+
+void MprisPlayerAdaptor::Pause()
+{
+    m_player->setProperty("pause", true);
+}
+
+void MprisPlayerAdaptor::Stop()
+{
+    m_player->command(QVariantList() << "stop");
+}
+
+void MprisPlayerAdaptor::Seek(qlonglong offsetUs)
+{
+    m_player->command(QVariantList() << "seek" << double(offsetUs) / 1e6 << "relative");
+    emit Seeked(position());
+}
+
+void MprisPlayerAdaptor::SetPosition(const QDBusObjectPath &, qlonglong positionUs)
+{
+    m_player->setProperty("time-pos", double(positionUs) / 1e6);
+    emit Seeked(positionUs);
+}
+
+void MprisPlayerAdaptor::onMpvEvent(const QString &event, const QVariant &value)
+{
+    if (event == "mpv-prop-change") {
+        QJsonObject obj = value.toJsonObject();
+        QString     name = obj["name"].toString();
+        QVariant    data = obj["data"].toVariant();
+
+        if (name == "core-idle") {
+            bool idle = data.toBool();
+            if (idle != m_idle) {
+                m_idle = idle;
+                if (m_idle) {
+                    m_title.clear();
+                    m_duration = 0.0;
+                }
+                emitPropertiesChanged({{"PlaybackStatus", playbackStatus()}});
+            }
+        } else if (name == "pause") {
+            bool paused = data.toBool();
+            if (paused != m_paused) {
+                m_paused = paused;
+                emitPropertiesChanged({{"PlaybackStatus", playbackStatus()}});
+            }
+        } else if (name == "media-title") {
+            m_title = data.toString();
+            emitPropertiesChanged({{"Metadata", QVariant::fromValue(metadata())}});
+        } else if (name == "duration") {
+            m_duration = data.toDouble();
+            emitPropertiesChanged({{"Metadata", QVariant::fromValue(metadata())}});
+        } else if (name == "volume") {
+            emitPropertiesChanged({{"Volume", data.toDouble() / 100.0}});
+        }
+    } else if (event == "mpv-event-ended") {
+        m_idle  = true;
+        m_title.clear();
+        m_duration = 0.0;
+        emitPropertiesChanged({{"PlaybackStatus", QString("Stopped")}});
+    }
+}
+
+void MprisPlayerAdaptor::emitPropertiesChanged(const QVariantMap &changed)
+{
+    auto msg = QDBusMessage::createSignal(
+        MPRIS_OBJECT_PATH,
+        "org.freedesktop.DBus.Properties",
+        "PropertiesChanged"
+    );
+    msg << QString(PLAYER_IFACE) << changed << QStringList();
+    QDBusConnection::sessionBus().send(msg);
+}
+
+// ─── Setup ────────────────────────────────────────────────────────────────────
+
+void mprisSetup(MpvObject *player)
+{
+    new MprisRootAdaptor(player);
+    new MprisPlayerAdaptor(player);
+
+    QDBusConnection bus = QDBusConnection::sessionBus();
+    if (!bus.registerObject(MPRIS_OBJECT_PATH, player)) {
+        qWarning("MPRIS: falha ao registrar objeto D-Bus em %s", MPRIS_OBJECT_PATH);
+        return;
+    }
+    if (!bus.registerService(SERVICE_NAME)) {
+        qWarning("MPRIS: falha ao registrar serviço %s", SERVICE_NAME);
+        return;
+    }
+    qDebug("MPRIS: registrado com sucesso — KDE Connect pode controlar o Stremio");
+}

--- a/mpris.cpp
+++ b/mpris.cpp
@@ -30,8 +30,7 @@ void MprisRootAdaptor::Raise()
 MprisPlayerAdaptor::MprisPlayerAdaptor(MpvObject *player)
     : QDBusAbstractAdaptor(player), m_player(player)
 {
-    // Observa as propriedades mpv relevantes para MPRIS
-    player->observeProperty("core-idle");
+    player->observeProperty("idle-active");
     player->observeProperty("pause");
     player->observeProperty("media-title");
     player->observeProperty("duration");
@@ -52,7 +51,7 @@ QVariantMap MprisPlayerAdaptor::metadata() const
 {
     QVariantMap map;
     map["mpris:trackid"] = QVariant::fromValue(
-        QDBusObjectPath("/org/stremio/track/0")
+        QDBusObjectPath(QString("/org/stremio/track/%1").arg(m_trackSeq))
     );
     if (!m_title.isEmpty())
         map["xesam:title"] = m_title;
@@ -103,8 +102,11 @@ void MprisPlayerAdaptor::Seek(qlonglong offsetUs)
     emit Seeked(position());
 }
 
-void MprisPlayerAdaptor::SetPosition(const QDBusObjectPath &, qlonglong positionUs)
+void MprisPlayerAdaptor::SetPosition(const QDBusObjectPath &trackId, qlonglong positionUs)
 {
+    // Ignore stale requests targeting a previous track
+    QString expected = QString("/org/stremio/track/%1").arg(m_trackSeq);
+    if (trackId.path() != expected) return;
     m_player->setProperty("time-pos", double(positionUs) / 1e6);
     emit Seeked(positionUs);
 }
@@ -116,15 +118,20 @@ void MprisPlayerAdaptor::onMpvEvent(const QString &event, const QVariant &value)
         QString     name = obj["name"].toString();
         QVariant    data = obj["data"].toVariant();
 
-        if (name == "core-idle") {
+        if (name == "idle-active") {
             bool idle = data.toBool();
             if (idle != m_idle) {
                 m_idle = idle;
                 if (m_idle) {
                     m_title.clear();
                     m_duration = 0.0;
+                    emitPropertiesChanged({
+                        {"PlaybackStatus", playbackStatus()},
+                        {"Metadata", QVariant::fromValue(metadata())}
+                    });
+                } else {
+                    emitPropertiesChanged({{"PlaybackStatus", playbackStatus()}});
                 }
-                emitPropertiesChanged({{"PlaybackStatus", playbackStatus()}});
             }
         } else if (name == "pause") {
             bool paused = data.toBool();
@@ -134,6 +141,7 @@ void MprisPlayerAdaptor::onMpvEvent(const QString &event, const QVariant &value)
             }
         } else if (name == "media-title") {
             m_title = data.toString();
+            m_trackSeq++;
             emitPropertiesChanged({{"Metadata", QVariant::fromValue(metadata())}});
         } else if (name == "duration") {
             m_duration = data.toDouble();
@@ -145,7 +153,10 @@ void MprisPlayerAdaptor::onMpvEvent(const QString &event, const QVariant &value)
         m_idle  = true;
         m_title.clear();
         m_duration = 0.0;
-        emitPropertiesChanged({{"PlaybackStatus", QString("Stopped")}});
+        emitPropertiesChanged({
+            {"PlaybackStatus", QString("Stopped")},
+            {"Metadata", QVariant::fromValue(metadata())}
+        });
     }
 }
 
@@ -169,12 +180,12 @@ void mprisSetup(MpvObject *player)
 
     QDBusConnection bus = QDBusConnection::sessionBus();
     if (!bus.registerObject(MPRIS_OBJECT_PATH, player)) {
-        qWarning("MPRIS: falha ao registrar objeto D-Bus em %s", MPRIS_OBJECT_PATH);
+        qWarning("MPRIS: failed to register D-Bus object at %s", MPRIS_OBJECT_PATH);
         return;
     }
     if (!bus.registerService(SERVICE_NAME)) {
-        qWarning("MPRIS: falha ao registrar serviço %s", SERVICE_NAME);
+        qWarning("MPRIS: failed to register service %s", SERVICE_NAME);
         return;
     }
-    qDebug("MPRIS: registrado com sucesso — KDE Connect pode controlar o Stremio");
+    qDebug("MPRIS: registered successfully — media controllers can now control Stremio");
 }

--- a/mpris.cpp
+++ b/mpris.cpp
@@ -18,12 +18,11 @@ void MprisRootAdaptor::Raise()
 {
     QQuickItem *item = qobject_cast<QQuickItem *>(parent());
     if (!item) return;
-    QWindow *win = item->window();
-    if (win) {
-        win->show();
-        win->raise();
-        win->requestActivate();
-    }
+    QQuickWindow *win = item->window();
+    if (!win) return;
+    win->show();
+    win->raise();
+    win->requestActivate();
 }
 
 // ─── MprisPlayerAdaptor ───────────────────────────────────────────────────────

--- a/mpris.h
+++ b/mpris.h
@@ -1,11 +1,11 @@
-#pragma once
+#ifndef MPRIS_H
+#define MPRIS_H
 
 #include <QtDBus/QDBusAbstractAdaptor>
 #include <QtDBus/QDBusConnection>
 #include <QtDBus/QDBusMessage>
 #include <QtDBus/QDBusObjectPath>
 #include <QVariantMap>
-#include <QWindow>
 
 #include "mpv.h"
 
@@ -105,3 +105,5 @@ private:
 };
 
 void mprisSetup(MpvObject *player);
+
+#endif // MPRIS_H

--- a/mpris.h
+++ b/mpris.h
@@ -1,0 +1,107 @@
+#pragma once
+
+#include <QtDBus/QDBusAbstractAdaptor>
+#include <QtDBus/QDBusConnection>
+#include <QtDBus/QDBusMessage>
+#include <QtDBus/QDBusObjectPath>
+#include <QVariantMap>
+#include <QWindow>
+
+#include "mpv.h"
+
+// org.mpris.MediaPlayer2 — interface raiz (identidade do player)
+class MprisRootAdaptor : public QDBusAbstractAdaptor {
+    Q_OBJECT
+    Q_CLASSINFO("D-Bus Interface", "org.mpris.MediaPlayer2")
+    Q_PROPERTY(bool        CanQuit              READ canQuit)
+    Q_PROPERTY(bool        CanRaise             READ canRaise)
+    Q_PROPERTY(bool        HasTrackList         READ hasTrackList)
+    Q_PROPERTY(QString     Identity             READ identity)
+    Q_PROPERTY(QString     DesktopEntry         READ desktopEntry)
+    Q_PROPERTY(QStringList SupportedUriSchemes  READ supportedUriSchemes)
+    Q_PROPERTY(QStringList SupportedMimeTypes   READ supportedMimeTypes)
+
+public:
+    explicit MprisRootAdaptor(QObject *parent);
+
+    bool        canQuit()             const { return false; }
+    bool        canRaise()            const { return true; }
+    bool        hasTrackList()        const { return false; }
+    QString     identity()            const { return "Stremio"; }
+    QString     desktopEntry()        const { return "stremio"; }
+    QStringList supportedUriSchemes() const { return {}; }
+    QStringList supportedMimeTypes()  const { return {}; }
+
+public slots:
+    void Raise();
+    void Quit() {}
+};
+
+// org.mpris.MediaPlayer2.Player — controle de playback
+class MprisPlayerAdaptor : public QDBusAbstractAdaptor {
+    Q_OBJECT
+    Q_CLASSINFO("D-Bus Interface", "org.mpris.MediaPlayer2.Player")
+    Q_PROPERTY(QString     PlaybackStatus  READ playbackStatus)
+    Q_PROPERTY(QString     LoopStatus      READ loopStatus)
+    Q_PROPERTY(double      Rate            READ rate)
+    Q_PROPERTY(bool        Shuffle         READ shuffle)
+    Q_PROPERTY(QVariantMap Metadata        READ metadata)
+    Q_PROPERTY(double      Volume          READ volume WRITE setVolume)
+    Q_PROPERTY(qlonglong   Position        READ position)
+    Q_PROPERTY(double      MinimumRate     READ minimumRate)
+    Q_PROPERTY(double      MaximumRate     READ maximumRate)
+    Q_PROPERTY(bool        CanGoNext       READ canGoNext)
+    Q_PROPERTY(bool        CanGoPrevious   READ canGoPrevious)
+    Q_PROPERTY(bool        CanPlay         READ canPlay)
+    Q_PROPERTY(bool        CanPause        READ canPause)
+    Q_PROPERTY(bool        CanSeek         READ canSeek)
+    Q_PROPERTY(bool        CanControl      READ canControl)
+
+public:
+    explicit MprisPlayerAdaptor(MpvObject *player);
+
+    QString     playbackStatus() const;
+    QString     loopStatus()     const { return "None"; }
+    double      rate()           const { return 1.0; }
+    bool        shuffle()        const { return false; }
+    QVariantMap metadata()       const;
+    double      volume()         const;
+    void        setVolume(double v);
+    qlonglong   position()       const;
+    double      minimumRate()    const { return 1.0; }
+    double      maximumRate()    const { return 1.0; }
+    bool        canGoNext()      const { return false; }
+    bool        canGoPrevious()  const { return false; }
+    bool        canPlay()        const { return true; }
+    bool        canPause()       const { return true; }
+    bool        canSeek()        const { return true; }
+    bool        canControl()     const { return true; }
+
+public slots:
+    void PlayPause();
+    void Play();
+    void Pause();
+    void Stop();
+    void Next()     {}
+    void Previous() {}
+    void Seek(qlonglong offsetUs);
+    void SetPosition(const QDBusObjectPath &trackId, qlonglong positionUs);
+    void OpenUri(const QString &uri) { Q_UNUSED(uri) }
+
+signals:
+    void Seeked(qlonglong positionUs);
+
+private slots:
+    void onMpvEvent(const QString &event, const QVariant &value);
+
+private:
+    void emitPropertiesChanged(const QVariantMap &changed);
+
+    MpvObject *m_player;
+    bool       m_idle   = true;
+    bool       m_paused = false;
+    QString    m_title;
+    double     m_duration = 0.0;
+};
+
+void mprisSetup(MpvObject *player);

--- a/mpris.h
+++ b/mpris.h
@@ -28,7 +28,7 @@ public:
     bool        canRaise()            const { return true; }
     bool        hasTrackList()        const { return false; }
     QString     identity()            const { return "Stremio"; }
-    QString     desktopEntry()        const { return "stremio"; }
+    QString     desktopEntry()        const { return "smartcode-stremio"; }
     QStringList supportedUriSchemes() const { return {}; }
     QStringList supportedMimeTypes()  const { return {}; }
 
@@ -98,10 +98,11 @@ private:
     void emitPropertiesChanged(const QVariantMap &changed);
 
     MpvObject *m_player;
-    bool       m_idle   = true;
-    bool       m_paused = false;
+    bool       m_idle      = true;
+    bool       m_paused    = false;
     QString    m_title;
-    double     m_duration = 0.0;
+    double     m_duration  = 0.0;
+    int        m_trackSeq  = 0;
 };
 
 void mprisSetup(MpvObject *player);

--- a/stremio.pro
+++ b/stremio.pro
@@ -70,6 +70,11 @@ SOURCES += main.cpp \
     qclipboardproxy.cpp \
     verifysig.c
 
+unix:!mac {
+    SOURCES += mpris.cpp
+    HEADERS += mpris.h
+}
+
 RESOURCES += qml.qrc
 
 # Additional import path used to resolve QML modules in Qt Creator's code model


### PR DESCRIPTION
## Problem

On Linux, Stremio does not expose an MPRIS2 D-Bus interface (`org.mpris.MediaPlayer2`). This means media controller clients — KDE Connect, GNOME Shell media panel, playerctl, and similar tools — cannot discover or control Stremio playback.

This has been a long-standing request (see #391, and the earlier stremio-linux-shell#15). A previous attempt (PR #464) was left unmerged.

## Solution

Implement the full MPRIS2 interface using Qt's D-Bus adaptor system (`QDBusAbstractAdaptor`), which is already a build dependency (`QT += dbus`).

Two new files, compiled on Linux only:

**`mpris.h` / `mpris.cpp`**
- `MprisRootAdaptor` — implements `org.mpris.MediaPlayer2` (Identity, CanRaise, Raise, etc.)
- `MprisPlayerAdaptor` — implements `org.mpris.MediaPlayer2.Player`:
  - PlayPause, Play, Pause, Stop, Seek, SetPosition
  - Volume read/write with `PropertiesChanged` notification
  - Metadata (title, duration) via `xesam:title` and `mpris:length`
  - Real-time `PlaybackStatus` (Playing / Paused / Stopped) by observing mpv properties `pause` and `core-idle` through the existing `mpvEvent` signal
  - `Seeked` signal emitted after Seek/SetPosition

**`stremio.pro`** — adds `mpris.cpp` to `SOURCES` for `unix:!mac` only.

**`main.cpp`** — calls `mprisSetup(mpv)` after the QML engine loads, locating the `MpvObject` instance via `findChild`.

## Testing

Tested on Debian 13 / KDE Plasma with KDE Connect:
- Player appears in KDE Connect media controller automatically
- Play / Pause works
- Volume slider works (bidirectional — phone updates when changed in app)
- Track title and duration show correctly
- Status transitions (Playing → Paused → Stopped) are accurate

Also verified with `playerctl`:
```
playerctl -p stremio status   # Playing / Paused / Stopped
playerctl -p stremio metadata  # title, length
playerctl -p stremio volume 0.5
```

## Notes

- No changes to Windows or macOS builds — all new code is inside `unix:!mac` guards
- QtDBus is already linked in `stremio.pro`; no new dependencies added
- Builds with `-Wall -Wextra` without warnings