### PR TITLE
Fix standard edit shortcuts in desktop shell

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -505,8 +505,28 @@ ApplicationWindow {
         }
 
         Action {
+            shortcut: StandardKey.Undo
+            onTriggered: webView.triggerWebAction(WebEngineView.Undo)
+        }
+        Action {
+            shortcut: StandardKey.Redo
+            onTriggered: webView.triggerWebAction(WebEngineView.Redo)
+        }
+        Action {
+            shortcut: StandardKey.Cut
+            onTriggered: webView.triggerWebAction(WebEngineView.Cut)
+        }
+        Action {
+            shortcut: StandardKey.Copy
+            onTriggered: webView.triggerWebAction(WebEngineView.Copy)
+        }
+        Action {
             shortcut: StandardKey.Paste
             onTriggered: webView.triggerWebAction(WebEngineView.Paste)
+        }
+        Action {
+            shortcut: StandardKey.SelectAll
+            onTriggered: webView.triggerWebAction(WebEngineView.SelectAll)
         }
 
         DropArea {


### PR DESCRIPTION
## Summary
- register missing standard edit actions for the desktop shell WebEngine view
- add Undo, Redo, Cut, Copy, and Select All alongside the existing Paste action

## Why
Editable WebEngine content already exposes these commands through the context menu, but only Paste had an app-level shortcut binding. This means standard text-editing shortcuts such as Cmd/Ctrl+A, Cmd/Ctrl+C, Cmd/Ctrl+X, and Cmd/Ctrl+Z may not be handled reliably in the desktop app.

## Validation
- `git diff --check origin/master...HEAD`
- initialized submodules successfully

Local build validation is still limited because this machine does not have the Qt5 development package/qmake available; CMake configure stops at missing `Qt5Config.cmake`.