### PR TITLE
Handle play-external IPC messages

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -101,7 +101,8 @@ ApplicationWindow {
                         onWindowMode(args[1]);
                         return;
                     }
-                    case 'open-external': {
+                    case 'open-external':
+                    case 'play-external': {
                         Qt.openUrlExternally(args[1]);
                         return;
                     }


### PR DESCRIPTION
## Summary

Handle `play-external` IPC messages in the v5 shell by routing them through the same native external-URL handler as `open-external`.

## Problem

The web UI emits `play-external` when a non-HTTP external-player link is selected, but the shell only dispatches `open-external`. The UI then shows “Stream opened in external player” even though no player launches.

## Fix

Accept both IPC command names and call `Qt.openUrlExternally(args[1])` for either one.

This restores external-player launching for macOS and preserves compatibility with callers using `open-external`.

Related: Stremio/stremio-bugs#1743

## Validation

- `git diff --check`
- Reproduced the failure on macOS 5.1.26 with IINA selected.
- Confirmed the corresponding local shell change allows the selected stream URL to reach IINA.
