### PR TITLE
docs: add Ubuntu build and desktop integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Please, refer to [WINDOWS.md](https://github.com/Stremio/stremio-shell/blob/mast
 
 Please, refer to [DEBIAN.md](https://github.com/Stremio/stremio-shell/blob/master/DEBIAN.md) for a detailed explanation of how to build the latest Stremio in Debian.
 
+### Build instructions for Ubuntu
+
+Please, refer to [UBUNTU.md](UBUNTU.md) for current Ubuntu build, install, and desktop-integration instructions.
+
 ### Build instructions for OpenSuseLeap 15.0
 
 Please, refer to [OpenSuseLeap.md](https://github.com/Stremio/stremio-shell/blob/master/OpenSuseLeap.md) for a detailed explanation of how to build the latest Stremio in OpenSuseLeap 15.0

--- a/UBUNTU.md
+++ b/UBUNTU.md
@@ -1,0 +1,89 @@
+# Build Stremio on Ubuntu
+
+These instructions were verified on Ubuntu 26.04 using the current `master` branch.
+
+> [!NOTE]
+> `DEBIAN.md` describes the older qmake build flow. The current `release.makefile`
+> configures and builds Stremio with CMake.
+
+## 1. Clone the repository
+
+```sh
+git clone --recurse-submodules -j8 https://github.com/Stremio/stremio-shell.git
+cd stremio-shell
+```
+
+If the repository was cloned without submodules, initialize them before building:
+
+```sh
+git submodule update --init --recursive -j8
+```
+
+## 2. Install dependencies
+
+```sh
+sudo apt-get update
+sudo apt-get install -y \
+  build-essential cmake pkgconf libssl-dev librsvg2-bin libmpv-dev \
+  qtdeclarative5-dev qtwebengine5-dev nodejs \
+  qml-module-qtwebchannel qml-module-qt-labs-platform \
+  qml-module-qtwebengine qml-module-qtquick-dialogs \
+  qml-module-qtquick-controls qml-module-qt-labs-settings \
+  qml-module-qt-labs-folderlistmodel
+```
+
+`qtwebengine5-dev` is required by the current CMake configuration. Installing
+`libqt5webview5-dev` alone does not provide the `Qt5WebEngine` CMake package.
+
+## 3. Build
+
+```sh
+make -f release.makefile
+```
+
+This command builds `build/stremio`, downloads the streaming-server script to
+`server.js`, and generates the application icons in `icons/`.
+
+## 4. Run from the checkout
+
+```sh
+./build/stremio
+```
+
+## 5. Install system-wide
+
+The repository install target installs Stremio and its streaming-server files
+under `/opt/stremio`.
+
+```sh
+sudo make -f release.makefile install
+sudo ln -sfn /opt/stremio/stremio /usr/local/bin/stremio
+```
+
+You can then run:
+
+```sh
+stremio
+```
+
+## 6. Add a desktop entry for the current user
+
+The included `desktop_integration.sh` script installs a desktop entry below
+`$XDG_DATA_HOME/applications` (or `~/.local/share/applications`). It uses
+`build/stremio` by default:
+
+```sh
+./desktop_integration.sh --install
+```
+
+To register the system-wide installation instead, set `STREMIO_EXECUTABLE`:
+
+```sh
+STREMIO_EXECUTABLE=/opt/stremio/stremio ./desktop_integration.sh --install
+```
+
+Remove the per-user desktop entry with:
+
+```sh
+./desktop_integration.sh --uninstall
+```

--- a/desktop_integration.sh
+++ b/desktop_integration.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+
+# Integrate a Stremio source build with the current user's desktop.
+
+set -Eeuo pipefail
+
+readonly DESKTOP_FILENAME="stremio.desktop"
+readonly SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+readonly EXECUTABLE="${STREMIO_EXECUTABLE:-${SCRIPT_DIR}/build/stremio}"
+readonly ICON_PATH="${STREMIO_ICON:-${SCRIPT_DIR}/images/stremio.svg}"
+
+if [[ "${EXECUTABLE}" != /* ]]; then
+  printf 'error: STREMIO_EXECUTABLE must be an absolute path\n' >&2
+  exit 1
+fi
+
+if [[ "${ICON_PATH}" != /* ]]; then
+  printf 'error: STREMIO_ICON must be an absolute path\n' >&2
+  exit 1
+fi
+
+if [[ -n "${XDG_DATA_HOME:-}" ]]; then
+  [[ "${XDG_DATA_HOME}" == /* ]] || {
+    printf 'error: XDG_DATA_HOME must be an absolute path\n' >&2
+    exit 1
+  }
+  readonly DATA_HOME="${XDG_DATA_HOME}"
+elif [[ -n "${HOME:-}" ]]; then
+  readonly DATA_HOME="${HOME}/.local/share"
+else
+  printf 'error: HOME is not set\n' >&2
+  exit 1
+fi
+
+readonly APPLICATIONS_DIR="${DATA_HOME}/applications"
+readonly DESKTOP_FILE="${APPLICATIONS_DIR}/${DESKTOP_FILENAME}"
+
+TEMP_FILE=""
+
+cleanup() {
+  if [[ -n "${TEMP_FILE}" && -e "${TEMP_FILE}" ]]; then
+    rm -f -- "${TEMP_FILE}"
+  fi
+}
+trap cleanup EXIT
+
+error() {
+  printf 'error: %s\n' "$1" >&2
+  exit 1
+}
+
+usage() {
+  cat <<'USAGE'
+Integrate a Stremio source build with the current user's desktop environment.
+
+Usage:
+  desktop_integration.sh --install    Install the Stremio desktop entry
+  desktop_integration.sh --uninstall  Remove the Stremio desktop entry
+  desktop_integration.sh --help       Show this help
+
+By default, the entry starts build/stremio next to this script. Override it
+with STREMIO_EXECUTABLE, for example /opt/stremio/stremio.
+
+The entry is installed below XDG_DATA_HOME/applications, or
+~/.local/share/applications when XDG_DATA_HOME is not set.
+USAGE
+}
+
+refresh_desktop_database() {
+  if command -v update-desktop-database >/dev/null 2>&1; then
+    if ! update-desktop-database --quiet "${APPLICATIONS_DIR}"; then
+      printf 'warning: could not refresh the desktop-entry cache\n' >&2
+    fi
+  fi
+}
+
+# Escape characters that are reserved in a quoted Desktop Entry Exec value.
+desktop_escape() {
+  printf '%s' "$1" | sed 's/[\\$"`]/\\&/g'
+}
+
+write_desktop_entry() {
+  local executable_escaped
+  executable_escaped="$(desktop_escape "${EXECUTABLE}")"
+
+  cat <<EOF
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=Stremio
+GenericName=Video Organizer
+Comment=Video organizer for movies, TV shows, and channels
+Exec="${executable_escaped}" %U
+Icon=${ICON_PATH}
+Terminal=false
+StartupNotify=true
+StartupWMClass=stremio
+Categories=AudioVideo;Video;Player;TV;
+MimeType=application/x-bittorrent;x-scheme-handler/magnet;x-scheme-handler/stremio;video/avi;video/msvideo;video/x-msvideo;video/mp4;video/x-matroska;
+EOF
+}
+
+install_desktop_entry() {
+  [[ -x "${EXECUTABLE}" ]] || error "Stremio executable not found or not executable: ${EXECUTABLE}"
+  [[ -f "${ICON_PATH}" ]] || error "Stremio icon not found: ${ICON_PATH}"
+
+  mkdir -p -- "${APPLICATIONS_DIR}"
+  TEMP_FILE="$(mktemp "${DESKTOP_FILE}.tmp.XXXXXX")" || error "could not create a temporary desktop entry"
+  write_desktop_entry >"${TEMP_FILE}" || error "could not write the desktop entry"
+  chmod 0644 "${TEMP_FILE}"
+  mv -f -- "${TEMP_FILE}" "${DESKTOP_FILE}"
+  TEMP_FILE=""
+
+  refresh_desktop_database
+  printf 'Installed Stremio desktop entry: %s\n' "${DESKTOP_FILE}"
+}
+
+uninstall_desktop_entry() {
+  if [[ -e "${DESKTOP_FILE}" || -L "${DESKTOP_FILE}" ]]; then
+    rm -f -- "${DESKTOP_FILE}"
+    refresh_desktop_database
+    printf 'Removed Stremio desktop entry: %s\n' "${DESKTOP_FILE}"
+  else
+    printf 'Stremio desktop entry is not installed: %s\n' "${DESKTOP_FILE}"
+  fi
+}
+
+if [[ "$#" -ne 1 ]]; then
+  usage
+  [[ "$#" -eq 0 ]] && exit 0
+  exit 1
+fi
+
+case "$1" in
+  -i|--install)
+    install_desktop_entry
+    ;;
+  -u|--uninstall)
+    uninstall_desktop_entry
+    ;;
+  -h|--help)
+    usage
+    ;;
+  *)
+    printf 'error: unknown option: %s\n\n' "$1" >&2
+    usage >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary

- add a Ubuntu 26.04-tested build and installation guide
- document that the current release Makefile uses CMake and requires `qtwebengine5-dev`
- add a per-user desktop integration script for source builds and `/opt` installations
- link the Ubuntu guide from the README

## Details

`UBUNTU.md` records the dependency and build findings from building the current `master` branch. It covers submodule initialization, the CMake-based release build, streaming-server setup performed by the Makefile, system-wide installation under `/opt/stremio`, and optional desktop registration.

The new `desktop_integration.sh` script creates or removes a user desktop entry below `XDG_DATA_HOME/applications` (or `~/.local/share/applications`). It defaults to `build/stremio` and accepts `STREMIO_EXECUTABLE=/opt/stremio/stremio` for a system-wide installation.

## Validation

- built successfully with `make -f release.makefile` on Ubuntu 26.04
- checked the generated executable shared-library resolution
- ran `node --check` on the downloaded `server.js`
- ran `bash -n` on `desktop_integration.sh`
- exercised `desktop_integration.sh --install` and `--uninstall` with an isolated `XDG_DATA_HOME`
- validated the generated entry with `desktop-file-validate`

## Related issue

Relates to #500.